### PR TITLE
perf: update directly after selecting an avatar

### DIFF
--- a/src/views/user/Profile.vue
+++ b/src/views/user/Profile.vue
@@ -280,6 +280,9 @@ export default {
         visible: false
       },
       updateAvatarForm: {
+        username: undefined,
+        nickname: undefined,
+        email: undefined,
         avatar: undefined,
         visible: false,
         saving: false,
@@ -387,6 +390,10 @@ export default {
           this.userForm.model = response.data.user
           this.statistics.data = response.data
           this.mfaParam.mfaType = this.userForm.model.mfaType && this.userForm.model.mfaType
+          // 记录原始用户信息
+          this.updateAvatarForm.username = response.data.user.username
+          this.updateAvatarForm.nickname = response.data.user.nickname
+          this.updateAvatarForm.email = response.data.user.email
         })
         .finally(() => {
           this.statistics.loading = false
@@ -522,7 +529,18 @@ export default {
     },
     handleUpdateAvatar() {
       this.userForm.model.avatar = this.updateAvatarForm.avatar
-      this.updateAvatarForm.visible = false
+      apiClient.user
+        .updateProfile(this.updateAvatarForm)
+        .then(response => {
+          this.$message.success('更新头像成功!')
+          this.updateAvatarForm.visible = false
+          this.userForm.model.avatar = response.data.avatar
+          this.setUser(Object.assign({}, this.userForm.model))
+        })
+        .catch(() => {
+          this.$message.error('更新头像失败!')
+          this.updateAvatarForm.visible = true
+        })
     }
   }
 }

--- a/src/views/user/Profile.vue
+++ b/src/views/user/Profile.vue
@@ -280,9 +280,6 @@ export default {
         visible: false
       },
       updateAvatarForm: {
-        username: undefined,
-        nickname: undefined,
-        email: undefined,
         avatar: undefined,
         visible: false,
         saving: false,
@@ -390,10 +387,6 @@ export default {
           this.userForm.model = response.data.user
           this.statistics.data = response.data
           this.mfaParam.mfaType = this.userForm.model.mfaType && this.userForm.model.mfaType
-          // 记录原始用户信息
-          this.updateAvatarForm.username = response.data.user.username
-          this.updateAvatarForm.nickname = response.data.user.nickname
-          this.updateAvatarForm.email = response.data.user.email
         })
         .finally(() => {
           this.statistics.loading = false
@@ -527,10 +520,11 @@ export default {
         this.$refs.avatarInput.focus()
       })
     },
-    handleUpdateAvatar() {
-      this.userForm.model.avatar = this.updateAvatarForm.avatar
+    async handleUpdateAvatar() {
+      const { updateAvatarData } = await apiClient.user.getProfile()
+      updateAvatarData.avatar = this.updateAvatarForm.avatar
       apiClient.user
-        .updateProfile(this.updateAvatarForm)
+        .updateProfile(updateAvatarData)
         .then(response => {
           this.$message.success('更新头像成功!')
           this.updateAvatarForm.visible = false


### PR DESCRIPTION
#### What type of PR is this?
/kind improvement
#### What this PR does / why we need it:
修改用户头像时提交表单只更新头像字段;
#### Which issue(s) this PR fixes:
[Fixes个人资料修改头像 #2450](https://github.com/halo-dev/halo/issues/2450)

#### Special notes for your reviewer:
ruibaby

#### Does this PR introduce a user-facing change?
之前: 修改头像 需要点击修改资料的保存按钮才可以保存新头像；
现在: 修改头像确定后直接保存新头像;

#### Does this PR introduce a user-facing change?
```release-note
NONE
```