### PR TITLE
chore: bump @halo-dev/api-client for attachment custom endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@formkit/inputs": "^1.0.0-beta.11",
     "@formkit/themes": "^1.0.0-beta.11",
     "@formkit/vue": "^1.0.0-beta.11",
-    "@halo-dev/api-client": "^0.0.35",
+    "@halo-dev/api-client": "^0.0.36",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
     "@halo-dev/richtext-editor": "^0.0.0-alpha.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@formkit/inputs': ^1.0.0-beta.11
       '@formkit/themes': ^1.0.0-beta.11
       '@formkit/vue': ^1.0.0-beta.11
-      '@halo-dev/api-client': ^0.0.35
+      '@halo-dev/api-client': ^0.0.36
       '@halo-dev/components': workspace:*
       '@halo-dev/console-shared': workspace:*
       '@halo-dev/richtext-editor': ^0.0.0-alpha.7
@@ -100,7 +100,7 @@ importers:
       '@formkit/inputs': 1.0.0-beta.11
       '@formkit/themes': 1.0.0-beta.11_tailwindcss@3.1.8
       '@formkit/vue': 1.0.0-beta.11_k5hp3txgeyj6le63abiyc7wx3u
-      '@halo-dev/api-client': 0.0.35
+      '@halo-dev/api-client': 0.0.36
       '@halo-dev/components': link:packages/components
       '@halo-dev/console-shared': link:packages/shared
       '@halo-dev/richtext-editor': 0.0.0-alpha.7_vue@3.2.40
@@ -1897,8 +1897,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/api-client/0.0.35:
-    resolution: {integrity: sha512-+WBXS2/tHmeugeiDNXmBrtV9NiU22lylzwcugH/eTXGy7MnpAG4j//o2OOYyhVcp9BUBoh7MHuu0UcyLHq1bgg==}
+  /@halo-dev/api-client/0.0.36:
+    resolution: {integrity: sha512-ZwJ9GBH6WxETCE/BD4PZWv3GUbHJXO33kvyEPsS/A4Qt7kmaQJKHuzI4wVqEoxcewNjC/PdnzuTiNSuSG4FzVA==}
     dev: false
 
   /@halo-dev/richtext-editor/0.0.0-alpha.7_vue@3.2.40:

--- a/src/modules/contents/attachments/components/AttachmentUploadModal.vue
+++ b/src/modules/contents/attachments/components/AttachmentUploadModal.vue
@@ -59,7 +59,7 @@ const onVisibleChange = (visible: boolean) => {
 
 const uploadHandler = computed(() => {
   return (file, config) =>
-    apiClient.extension.storage.attachment.uploadAttachment(
+    apiClient.attachment.uploadAttachment(
       {
         file,
         policyName: selectedPolicy.value?.metadata.name as string,

--- a/src/modules/contents/attachments/components/selector-providers/UploadSelectorProvider.vue
+++ b/src/modules/contents/attachments/components/selector-providers/UploadSelectorProvider.vue
@@ -71,7 +71,7 @@ const selectedAttachments = ref<Set<Attachment>>(new Set<Attachment>());
 
 const uploadHandler = computed(() => {
   return (file, config) =>
-    apiClient.extension.storage.attachment.uploadAttachment(
+    apiClient.attachment.uploadAttachment(
       {
         file,
         policyName: selectedPolicy.value,

--- a/src/modules/contents/attachments/composables/use-attachment.ts
+++ b/src/modules/contents/attachments/composables/use-attachment.ts
@@ -69,15 +69,14 @@ export function useAttachmentControl(filterOptions?: {
   const handleFetchAttachments = async () => {
     try {
       loading.value = true;
-      const { data } =
-        await apiClient.extension.storage.attachment.searchAttachments({
-          policy: policy?.value?.metadata.name,
-          displayName: keyword?.value,
-          group: group?.value?.metadata.name,
-          uploadedBy: user?.value?.metadata.name,
-          page: attachments.value.page,
-          size: attachments.value.size,
-        });
+      const { data } = await apiClient.attachment.searchAttachments({
+        policy: policy?.value?.metadata.name,
+        displayName: keyword?.value,
+        group: group?.value?.metadata.name,
+        uploadedBy: user?.value?.metadata.name,
+        page: attachments.value.page,
+        size: attachments.value.size,
+      });
       attachments.value = data;
     } catch (e) {
       console.error("Failed to fetch attachments", e);

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -8,6 +8,7 @@ import {
   ApiConsoleHaloRunV1alpha1CommentApi,
   ApiConsoleHaloRunV1alpha1ReplyApi,
   ApiConsoleHaloRunV1alpha1StatsApi,
+  ApiConsoleHaloRunV1alpha1AttachmentApi,
   ContentHaloRunV1alpha1CategoryApi,
   ContentHaloRunV1alpha1CommentApi,
   ContentHaloRunV1alpha1PostApi,
@@ -129,6 +130,11 @@ function setupApiClient(axios: AxiosInstance) {
     comment: new ApiConsoleHaloRunV1alpha1CommentApi(undefined, baseURL, axios),
     reply: new ApiConsoleHaloRunV1alpha1ReplyApi(undefined, baseURL, axios),
     stats: new ApiConsoleHaloRunV1alpha1StatsApi(undefined, baseURL, axios),
+    attachment: new ApiConsoleHaloRunV1alpha1AttachmentApi(
+      undefined,
+      baseURL,
+      axios
+    ),
   };
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/milestone 2.0

#### What this PR does / why we need it:

升级 `@halo-dev/api-client` 版本以适配 Attachment 资源的自定义 Endpoint。

#### Special notes for your reviewer:

/cc @halo-dev/sig-halo-console 

测试方式：

1. 需要 `pnpm install`。
2. 测试附件列表和上传的功能。

#### Does this PR introduce a user-facing change?

```release-note
None
```
