### PR TITLE
feat: add setup primary menu support

### DIFF
--- a/src/views/system/setup-data/menu.json
+++ b/src/views/system/setup-data/menu.json
@@ -10,5 +10,5 @@
   },
   "apiVersion": "v1alpha1",
   "kind": "Menu",
-  "metadata": { "name": "2f0ef354-6f8f-40b9-b41d-2163f3e51b4f" }
+  "metadata": { "name": "primary" }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/milestone 2.0

#### What this PR does / why we need it:

支持设置主菜单。 适配 https://github.com/halo-dev/halo/pull/2667

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2533

#### Screenshots:

<img width="503" alt="image" src="https://user-images.githubusercontent.com/21301288/200283150-1292821e-ad4b-4909-865b-fcdba94ae4c2.png">

#### Special notes for your reviewer:

/cc @halo-dev/sig-halo-console 

测试方式：

1. Halo 需要使用 https://github.com/halo-dev/halo/pull/2667 分支。
2. 在 Console 的菜单管理新建若干个菜单。
3. 选择一个菜单点击更多按钮，再点击设置为主菜单按钮，检查是否生效。

#### Does this PR introduce a user-facing change?

```release-note
菜单管理支持设置主菜单。 
```
