### PR TITLE
refactor: post and singlePage publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@formkit/inputs": "^1.0.0-beta.11",
     "@formkit/themes": "^1.0.0-beta.11",
     "@formkit/vue": "^1.0.0-beta.11",
-    "@halo-dev/api-client": "^0.0.41",
+    "@halo-dev/api-client": "^0.0.42",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
     "@halo-dev/richtext-editor": "^0.0.0-alpha.8",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@formkit/inputs": "^1.0.0-beta.11",
     "@formkit/themes": "^1.0.0-beta.11",
     "@formkit/vue": "^1.0.0-beta.11",
-    "@halo-dev/api-client": "^0.0.42",
+    "@halo-dev/api-client": "^0.0.43",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
     "@halo-dev/richtext-editor": "^0.0.0-alpha.8",

--- a/packages/components/src/components/status/StatusDot.vue
+++ b/packages/components/src/components/status/StatusDot.vue
@@ -40,7 +40,7 @@ const classes = computed(() => {
   }
 
   .status-dot-text {
-    @apply text-gray-500;
+    @apply text-gray-500 text-xs;
   }
 
   &.status-dot-animate {

--- a/packages/components/src/icons/icons.ts
+++ b/packages/components/src/icons/icons.ts
@@ -52,6 +52,8 @@ import IconReplyLine from "~icons/ri/reply-line";
 import IconExternalLinkLine from "~icons/ri/external-link-line";
 import IconRefreshLine from "~icons/ri/refresh-line";
 import IconWindowLine from "~icons/ri/window-line";
+import IconSendPlaneFill from "~icons/ri/send-plane-fill";
+import IconRocketLine from "~icons/ri/rocket-line";
 
 export {
   IconDashboard,
@@ -108,4 +110,6 @@ export {
   IconExternalLinkLine,
   IconRefreshLine,
   IconWindowLine,
+  IconSendPlaneFill,
+  IconRocketLine,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@formkit/inputs': ^1.0.0-beta.11
       '@formkit/themes': ^1.0.0-beta.11
       '@formkit/vue': ^1.0.0-beta.11
-      '@halo-dev/api-client': ^0.0.41
+      '@halo-dev/api-client': ^0.0.42
       '@halo-dev/components': workspace:*
       '@halo-dev/console-shared': workspace:*
       '@halo-dev/richtext-editor': ^0.0.0-alpha.8
@@ -108,7 +108,7 @@ importers:
       '@formkit/inputs': 1.0.0-beta.11
       '@formkit/themes': 1.0.0-beta.11_tailwindcss@3.2.1
       '@formkit/vue': 1.0.0-beta.11_vjnbgdptsk6bkj7ab5a6mk2cwm
-      '@halo-dev/api-client': 0.0.41
+      '@halo-dev/api-client': 0.0.42
       '@halo-dev/components': link:packages/components
       '@halo-dev/console-shared': link:packages/shared
       '@halo-dev/richtext-editor': 0.0.0-alpha.8_vue@3.2.41
@@ -1953,8 +1953,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/api-client/0.0.41:
-    resolution: {integrity: sha512-YpwoIyT+6BjNEfhQqZPSG7dewmC9AE7wxc/uaIRcVZdKr0C4GLmbiBKGOFFnVWIYr42islhMWjqYCGaiJSzkUg==}
+  /@halo-dev/api-client/0.0.42:
+    resolution: {integrity: sha512-B49ny0ZsgaCGHsbIo39oouMy/W0j/qz3llqj1V+0rHsnIAvcOTTz6YLKztg6owhmn2ZcycM8hCXdg2TxyE5bLw==}
     dev: false
 
   /@halo-dev/richtext-editor/0.0.0-alpha.8_vue@3.2.41:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@formkit/inputs': ^1.0.0-beta.11
       '@formkit/themes': ^1.0.0-beta.11
       '@formkit/vue': ^1.0.0-beta.11
-      '@halo-dev/api-client': ^0.0.42
+      '@halo-dev/api-client': ^0.0.43
       '@halo-dev/components': workspace:*
       '@halo-dev/console-shared': workspace:*
       '@halo-dev/richtext-editor': ^0.0.0-alpha.8
@@ -108,7 +108,7 @@ importers:
       '@formkit/inputs': 1.0.0-beta.11
       '@formkit/themes': 1.0.0-beta.11_tailwindcss@3.2.1
       '@formkit/vue': 1.0.0-beta.11_vjnbgdptsk6bkj7ab5a6mk2cwm
-      '@halo-dev/api-client': 0.0.42
+      '@halo-dev/api-client': 0.0.43
       '@halo-dev/components': link:packages/components
       '@halo-dev/console-shared': link:packages/shared
       '@halo-dev/richtext-editor': 0.0.0-alpha.8_vue@3.2.41
@@ -1953,8 +1953,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/api-client/0.0.42:
-    resolution: {integrity: sha512-B49ny0ZsgaCGHsbIo39oouMy/W0j/qz3llqj1V+0rHsnIAvcOTTz6YLKztg6owhmn2ZcycM8hCXdg2TxyE5bLw==}
+  /@halo-dev/api-client/0.0.43:
+    resolution: {integrity: sha512-bCh5P7AYCYA/nVbAB/t62acrtOaDs8UItFe4JmK1qfeb5vOmFT2FT9jeJFj4ABqa4t4xJxy9hnoxNm6H+iB3IQ==}
     dev: false
 
   /@halo-dev/richtext-editor/0.0.0-alpha.8_vue@3.2.41:

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -11,6 +11,16 @@ export enum roleLabels {
 // post
 export enum postLabels {
   DELETED = "content.halo.run/deleted",
+  PUBLISHED = "content.halo.run/published",
+  OWNER = "content.halo.run/owner",
+  VISIBLE = "content.halo.run/visible",
+  PHASE = "content.halo.run/phase",
+}
+
+// singlePage
+export enum singlePageLabels {
+  DELETED = "content.halo.run/deleted",
+  PUBLISHED = "content.halo.run/published",
   OWNER = "content.halo.run/owner",
   VISIBLE = "content.halo.run/visible",
   PHASE = "content.halo.run/phase",

--- a/src/modules/contents/pages/SinglePageEditor.vue
+++ b/src/modules/contents/pages/SinglePageEditor.vue
@@ -31,7 +31,7 @@ const initialFormState: SinglePageRequest = {
       template: "",
       cover: "",
       deleted: false,
-      published: false,
+      publish: false,
       publishTime: "",
       pinned: false,
       allowComment: true,

--- a/src/modules/contents/pages/SinglePageList.vue
+++ b/src/modules/contents/pages/SinglePageList.vue
@@ -85,7 +85,7 @@ const handleFetchSinglePages = async () => {
     });
     singlePages.value = data;
 
-    const deletedSinglePages = singlePages.value.items.filter((singlePage) => {
+    const abnormalSinglePages = singlePages.value.items.filter((singlePage) => {
       const { spec, metadata, status } = singlePage.page;
       return (
         spec.deleted ||
@@ -95,7 +95,7 @@ const handleFetchSinglePages = async () => {
       );
     });
 
-    if (deletedSinglePages.length) {
+    if (abnormalSinglePages.length) {
       refreshInterval.value = setInterval(() => {
         handleFetchSinglePages();
       }, 1000);

--- a/src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -1,71 +1,70 @@
 <script lang="ts" setup>
 import { VButton, VModal, VSpace, VTabItem, VTabs } from "@halo-dev/components";
 import { computed, ref, watchEffect } from "vue";
-import type { SinglePageRequest } from "@halo-dev/api-client";
+import type { SinglePage } from "@halo-dev/api-client";
 import cloneDeep from "lodash.clonedeep";
 import { apiClient } from "@/utils/api-client";
 import { v4 as uuid } from "uuid";
 import { useThemeCustomTemplates } from "@/modules/interface/themes/composables/use-theme";
+import { singlePageLabels } from "@/constants/labels";
 
-const initialFormState: SinglePageRequest = {
-  page: {
-    spec: {
-      title: "",
-      slug: "",
-      template: "",
-      cover: "",
-      deleted: false,
-      publish: false,
-      publishTime: "",
-      pinned: false,
-      allowComment: true,
-      visible: "PUBLIC",
-      version: 1,
-      priority: 0,
-      excerpt: {
-        autoGenerate: true,
-        raw: "",
-      },
-      htmlMetas: [],
+const initialFormState: SinglePage = {
+  spec: {
+    title: "",
+    slug: "",
+    template: "",
+    cover: "",
+    deleted: false,
+    publish: false,
+    publishTime: "",
+    pinned: false,
+    allowComment: true,
+    visible: "PUBLIC",
+    version: 1,
+    priority: 0,
+    excerpt: {
+      autoGenerate: true,
+      raw: "",
     },
-    apiVersion: "content.halo.run/v1alpha1",
-    kind: "SinglePage",
-    metadata: {
-      name: uuid(),
-    },
+    htmlMetas: [],
   },
-  content: {
-    raw: "",
-    content: "",
-    rawType: "HTML",
+  apiVersion: "content.halo.run/v1alpha1",
+  kind: "SinglePage",
+  metadata: {
+    name: uuid(),
   },
 };
 
 const props = withDefaults(
   defineProps<{
     visible: boolean;
-    singlePage?: SinglePageRequest;
+    singlePage?: SinglePage;
+    publishSupport?: boolean;
+    onlyEmit?: boolean;
   }>(),
   {
     visible: false,
     singlePage: undefined,
+    publishSupport: true,
+    onlyEmit: false,
   }
 );
 
 const emit = defineEmits<{
   (event: "update:visible", visible: boolean): void;
   (event: "close"): void;
-  (event: "saved", singlePage: SinglePageRequest): void;
+  (event: "saved", singlePage: SinglePage): void;
+  (event: "published", singlePage: SinglePage): void;
 }>();
 
 const activeTab = ref("general");
-const formState = ref<SinglePageRequest>(cloneDeep(initialFormState));
+const formState = ref<SinglePage>(cloneDeep(initialFormState));
 const saving = ref(false);
 const publishing = ref(false);
 const publishCanceling = ref(false);
 
 const isUpdateMode = computed(() => {
-  return !!formState.value.page.metadata.creationTimestamp;
+  return !!formState.value.metadata.creationTimestamp;
 });
 
 const onVisibleChange = (visible: boolean) => {
@@ -76,26 +75,33 @@ const onVisibleChange = (visible: boolean) => {
 };
 
 const handleSave = async () => {
+  if (props.onlyEmit) {
+    emit("saved", formState.value);
+    return;
+  }
+
   try {
     saving.value = true;
 
-    // Set rendered content
-    formState.value.content.content = formState.value.content.raw;
+    saving.value = true;
 
-    if (isUpdateMode.value) {
-      const { data } = await apiClient.singlePage.updateDraftSinglePage({
-        name: formState.value.page.metadata.name,
-        singlePageRequest: formState.value,
-      });
-      formState.value.page = data;
-      emit("saved", formState.value);
-    } else {
-      const { data } = await apiClient.singlePage.draftSinglePage({
-        singlePageRequest: formState.value,
-      });
-      formState.value.page = data;
-      emit("saved", formState.value);
-    }
+    const { data } = isUpdateMode.value
+      ? await apiClient.extension.singlePage.updatecontentHaloRunV1alpha1SinglePage(
+          {
+            name: formState.value.metadata.name,
+            singlePage: formState.value,
+          }
+        )
+      : await apiClient.extension.singlePage.createcontentHaloRunV1alpha1SinglePage(
+          {
+            singlePage: formState.value,
+          }
+        );
+
+    formState.value = data;
+    emit("saved", data);
+
+    onVisibleChange(false);
   } catch (error) {
     console.error("Failed to save single page", error);
   } finally {
@@ -103,55 +109,44 @@ const handleSave = async () => {
   }
 };
 
-const handlePublish = async () => {
+const handleSwitchPublish = async (publish: boolean) => {
+  if (props.onlyEmit) {
+    emit("published", formState.value);
+    return;
+  }
+
   try {
-    publishing.value = true;
+    if (publish) {
+      publishing.value = true;
+    } else {
+      publishCanceling.value = true;
+    }
 
-    // Save single page
-    await handleSave();
+    const { data } =
+      await apiClient.extension.singlePage.updatecontentHaloRunV1alpha1SinglePage(
+        {
+          name: formState.value.metadata.name,
+          singlePage: {
+            ...formState.value,
+            spec: {
+              ...formState.value.spec,
+              publish: publish,
+            },
+          },
+        }
+      );
 
-    // Get latest version single page
-    const { data: latestData } =
-      await apiClient.extension.singlePage.getcontentHaloRunV1alpha1SinglePage({
-        name: formState.value.page.metadata.name,
-      });
-    formState.value.page = latestData;
+    formState.value = data;
 
-    // Publish single page
-    const { data } = await apiClient.singlePage.publishSinglePage({
-      name: formState.value.page.metadata.name,
-    });
-    formState.value.page = data;
-    emit("saved", formState.value);
+    if (publish) {
+      emit("published", data);
+    }
+
+    onVisibleChange(false);
   } catch (error) {
     console.error("Failed to publish single page", error);
   } finally {
     publishing.value = false;
-  }
-};
-
-const handleCancelPublish = async () => {
-  try {
-    publishCanceling.value = true;
-
-    // Update published spec = false
-    const singlePageToUpdate = cloneDeep(formState.value);
-    singlePageToUpdate.page.spec.publish = false;
-    await apiClient.singlePage.updateDraftSinglePage({
-      name: singlePageToUpdate.page.metadata.name,
-      singlePageRequest: singlePageToUpdate,
-    });
-
-    // Get latest version single page
-    const { data: latestData } =
-      await apiClient.extension.singlePage.getcontentHaloRunV1alpha1SinglePage({
-        name: formState.value.page.metadata.name,
-      });
-    formState.value.page = latestData;
-    emit("saved", formState.value);
-  } catch (error) {
-    console.error("Failed to cancel publish single page", error);
-  } finally {
     publishCanceling.value = false;
   }
 };
@@ -188,21 +183,21 @@ const { templates } = useThemeCustomTemplates("page");
           type="form"
         >
           <FormKit
-            v-model="formState.page.spec.title"
+            v-model="formState.spec.title"
             label="标题"
             type="text"
             name="title"
             validation="required"
           ></FormKit>
           <FormKit
-            v-model="formState.page.spec.slug"
+            v-model="formState.spec.slug"
             label="别名"
             name="slug"
             type="text"
             validation="required"
           ></FormKit>
           <FormKit
-            v-model="formState.page.spec.excerpt.autoGenerate"
+            v-model="formState.spec.excerpt.autoGenerate"
             :options="[
               { label: '是', value: true },
               { label: '否', value: false },
@@ -213,8 +208,8 @@ const { templates } = useThemeCustomTemplates("page");
           >
           </FormKit>
           <FormKit
-            v-if="!formState.page.spec.excerpt.autoGenerate"
-            v-model="formState.page.spec.excerpt.raw"
+            v-if="!formState.spec.excerpt.autoGenerate"
+            v-model="formState.spec.excerpt.raw"
             name="raw"
             label="自定义摘要"
             type="textarea"
@@ -231,7 +226,7 @@ const { templates } = useThemeCustomTemplates("page");
           type="form"
         >
           <FormKit
-            v-model="formState.page.spec.allowComment"
+            v-model="formState.spec.allowComment"
             :options="[
               { label: '是', value: true },
               { label: '否', value: false },
@@ -241,7 +236,7 @@ const { templates } = useThemeCustomTemplates("page");
             type="radio"
           ></FormKit>
           <FormKit
-            v-model="formState.page.spec.pinned"
+            v-model="formState.spec.pinned"
             :options="[
               { label: '是', value: true },
               { label: '否', value: false },
@@ -251,7 +246,7 @@ const { templates } = useThemeCustomTemplates("page");
             type="radio"
           ></FormKit>
           <FormKit
-            v-model="formState.page.spec.visible"
+            v-model="formState.spec.visible"
             :options="[
               { label: '公开', value: 'PUBLIC' },
               { label: '内部成员可访问', value: 'INTERNAL' },
@@ -262,20 +257,20 @@ const { templates } = useThemeCustomTemplates("page");
             type="select"
           ></FormKit>
           <FormKit
-            v-model="formState.page.spec.publishTime"
+            v-model="formState.spec.publishTime"
             label="发表时间"
             type="datetime-local"
             name="publishTime"
           ></FormKit>
           <FormKit
-            v-model="formState.page.spec.template"
+            v-model="formState.spec.template"
             :options="templates"
             label="自定义模板"
             type="select"
             name="template"
           ></FormKit>
           <FormKit
-            v-model="formState.page.spec.cover"
+            v-model="formState.spec.cover"
             label="封面图"
             type="attachment"
             name="cover"
@@ -287,27 +282,28 @@ const { templates } = useThemeCustomTemplates("page");
 
     <template #footer>
       <VSpace>
-        <VButton :loading="publishing" type="secondary" @click="handlePublish">
-          {{
-            formState.page.status?.phase === "PUBLISHED" ? "重新发布" : "发布"
-          }}
-        </VButton>
-        <VButton
-          :loading="saving"
-          size="sm"
-          type="secondary"
-          @click="handleSave"
-        >
-          仅保存
-        </VButton>
-        <VButton
-          v-if="formState.page.status?.phase === 'PUBLISHED'"
-          :loading="publishCanceling"
-          type="danger"
-          size="sm"
-          @click="handleCancelPublish"
-        >
-          取消发布
+        <template v-if="publishSupport">
+          <VButton
+            v-if="
+              formState.metadata.labels?.[singlePageLabels.PUBLISHED] !== 'true'
+            "
+            :loading="publishing"
+            type="secondary"
+            @click="handleSwitchPublish(true)"
+          >
+            发布
+          </VButton>
+          <VButton
+            v-else
+            :loading="publishCanceling"
+            type="danger"
+            @click="handleSwitchPublish(false)"
+          >
+            取消发布
+          </VButton>
+        </template>
+        <VButton :loading="saving" type="secondary" @click="handleSave">
+          保存
         </VButton>
         <VButton size="sm" type="default" @click="onVisibleChange(false)">
           关闭

--- a/src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -122,6 +122,10 @@ const handleSwitchPublish = async (publish: boolean) => {
       publishCanceling.value = true;
     }
 
+    if (publish) {
+      formState.value.spec.releaseSnapshot = formState.value.spec.headSnapshot;
+    }
+
     const { data } =
       await apiClient.extension.singlePage.updatecontentHaloRunV1alpha1SinglePage(
         {

--- a/src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -15,7 +15,7 @@ const initialFormState: SinglePageRequest = {
       template: "",
       cover: "",
       deleted: false,
-      published: false,
+      publish: false,
       publishTime: "",
       pinned: false,
       allowComment: true,
@@ -136,7 +136,7 @@ const handleCancelPublish = async () => {
 
     // Update published spec = false
     const singlePageToUpdate = cloneDeep(formState.value);
-    singlePageToUpdate.page.spec.published = false;
+    singlePageToUpdate.page.spec.publish = false;
     await apiClient.singlePage.updateDraftSinglePage({
       name: singlePageToUpdate.page.metadata.name,
       singlePageRequest: singlePageToUpdate,

--- a/src/modules/contents/posts/PostEditor.vue
+++ b/src/modules/contents/posts/PostEditor.vue
@@ -15,7 +15,7 @@ import {
 import PostSettingModal from "./components/PostSettingModal.vue";
 import PostPreviewModal from "./components/PostPreviewModal.vue";
 import AttachmentSelectorModal from "../attachments/components/AttachmentSelectorModal.vue";
-import type { PostRequest } from "@halo-dev/api-client";
+import type { Post, PostRequest } from "@halo-dev/api-client";
 import { computed, markRaw, nextTick, onMounted, ref, watch } from "vue";
 import cloneDeep from "lodash.clonedeep";
 import { apiClient } from "@/utils/api-client";
@@ -201,6 +201,7 @@ const handleSave = async () => {
     if (!formState.value.post.spec.title) {
       formState.value.post.spec.title = "无标题文章";
     }
+
     if (!formState.value.post.spec.slug) {
       formState.value.post.spec.slug = uuid();
     }
@@ -238,13 +239,13 @@ const handleFetchContent = async () => {
   formState.value.content = data;
 };
 
-const onSettingSaved = (post: PostRequest) => {
+const onSettingSaved = (post: Post) => {
   // Set route query parameter
   if (!isUpdateMode.value) {
-    name.value = post.post.metadata.name;
+    name.value = post.metadata.name;
   }
 
-  formState.value = post;
+  formState.value.post = post;
   settingModal.value = false;
 };
 
@@ -269,7 +270,7 @@ onMounted(async () => {
 <template>
   <PostSettingModal
     v-model:visible="settingModal"
-    :post="formState"
+    :post="formState.post"
     @saved="onSettingSaved"
   />
   <PostPreviewModal v-model:visible="previewModal" :post="formState.post" />

--- a/src/modules/contents/posts/PostEditor.vue
+++ b/src/modules/contents/posts/PostEditor.vue
@@ -6,6 +6,8 @@ import {
   IconLink,
   IconSave,
   IconUserFollow,
+  IconSettings,
+  IconSendPlaneFill,
   VButton,
   VPageHeader,
   VSpace,
@@ -228,10 +230,23 @@ const handleSave = async () => {
   }
 };
 
+const handlePublish = () => {
+  // TODO
+};
+
+const handlePublishClick = () => {
+  if (isUpdateMode.value) {
+    handlePublish();
+  } else {
+    settingModal.value = true;
+  }
+};
+
 const handleFetchContent = async () => {
   if (!formState.value.post.spec.headSnapshot) {
     return;
   }
+
   const { data } = await apiClient.content.obtainSnapshotContent({
     snapshotName: formState.value.post.spec.headSnapshot,
   });
@@ -294,11 +309,25 @@ onMounted(async () => {
           预览
         </VButton>
         <VButton :loading="saving" size="sm" type="default" @click="handleSave">
-          保存
-        </VButton>
-        <VButton type="secondary" @click="settingModal = true">
           <template #icon>
             <IconSave class="h-full w-full" />
+          </template>
+          保存
+        </VButton>
+        <VButton
+          v-if="isUpdateMode"
+          size="sm"
+          type="default"
+          @click="settingModal = true"
+        >
+          <template #icon>
+            <IconSettings class="h-full w-full" />
+          </template>
+          设置
+        </VButton>
+        <VButton type="secondary" @click="handlePublishClick">
+          <template #icon>
+            <IconSendPlaneFill class="h-full w-full" />
           </template>
           发布
         </VButton>

--- a/src/modules/contents/posts/PostEditor.vue
+++ b/src/modules/contents/posts/PostEditor.vue
@@ -46,7 +46,7 @@ const initialFormState: PostRequest = {
       template: "",
       cover: "",
       deleted: false,
-      published: false,
+      publish: false,
       publishTime: "",
       pinned: false,
       allowComment: true,

--- a/src/modules/contents/posts/PostList.vue
+++ b/src/modules/contents/posts/PostList.vue
@@ -25,13 +25,12 @@ import {
 import UserDropdownSelector from "@/components/dropdown-selector/UserDropdownSelector.vue";
 import PostSettingModal from "./components/PostSettingModal.vue";
 import PostTag from "../posts/tags/components/PostTag.vue";
-import { onMounted, ref, watch, watchEffect } from "vue";
+import { onMounted, ref, watch } from "vue";
 import type {
   User,
   Category,
   ListedPostList,
   Post,
-  PostRequest,
   Tag,
 } from "@halo-dev/api-client";
 import { apiClient } from "@/utils/api-client";
@@ -57,8 +56,7 @@ const posts = ref<ListedPostList>({
 });
 const loading = ref(false);
 const settingModal = ref(false);
-const selectedPost = ref<Post | null>(null);
-const selectedPostWithContent = ref<PostRequest | null>(null);
+const selectedPost = ref<Post>();
 const checkedAll = ref(false);
 const selectedPostNames = ref<string[]>([]);
 const refreshInterval = ref();
@@ -152,8 +150,7 @@ const handleOpenSettingModal = async (post: Post) => {
 };
 
 const onSettingModalClose = () => {
-  selectedPost.value = null;
-  selectedPostWithContent.value = null;
+  selectedPost.value = undefined;
   handleFetchPosts();
 };
 
@@ -270,21 +267,6 @@ const handleDeleteInBatch = async () => {
 
 watch(selectedPostNames, (newValue) => {
   checkedAll.value = newValue.length === posts.value.items?.length;
-});
-
-watchEffect(async () => {
-  if (!selectedPost.value || !selectedPost.value.spec.headSnapshot) {
-    return;
-  }
-
-  const { data: content } = await apiClient.content.obtainSnapshotContent({
-    snapshotName: selectedPost.value.spec.headSnapshot,
-  });
-
-  selectedPostWithContent.value = {
-    post: selectedPost.value,
-    content: content,
-  };
 });
 
 onMounted(() => {
@@ -410,7 +392,7 @@ function handleContributorChange(user?: User) {
 <template>
   <PostSettingModal
     v-model:visible="settingModal"
-    :post="selectedPostWithContent"
+    :post="selectedPost"
     @close="onSettingModalClose"
   >
     <template #actions>

--- a/src/modules/contents/posts/components/PostSettingModal.vue
+++ b/src/modules/contents/posts/components/PostSettingModal.vue
@@ -118,6 +118,10 @@ const handleSwitchPublish = async (publish: boolean) => {
       publishCanceling.value = true;
     }
 
+    if (publish) {
+      formState.value.spec.releaseSnapshot = formState.value.spec.headSnapshot;
+    }
+
     const { data } =
       await apiClient.extension.post.updatecontentHaloRunV1alpha1Post({
         name: formState.value.metadata.name,

--- a/src/modules/contents/posts/components/PostSettingModal.vue
+++ b/src/modules/contents/posts/components/PostSettingModal.vue
@@ -268,34 +268,25 @@ const { templates } = useThemeCustomTemplates("post");
     <template #footer>
       <VSpace>
         <VButton
+          v-if="formState.metadata.labels?.[postLabels.PUBLISHED] !== 'true'"
           :loading="publishing"
           type="secondary"
           @click="handleSwitchPublish(true)"
         >
-          {{
-            formState.metadata.labels?.[postLabels.PUBLISHED] === "true"
-              ? "重新发布"
-              : "发布"
-          }}
+          发布
         </VButton>
         <VButton
-          :loading="saving"
-          size="sm"
-          type="secondary"
-          @click="handleSave"
-        >
-          保存
-        </VButton>
-        <VButton
-          v-if="formState.status?.phase === 'PUBLISHED'"
+          v-else
           :loading="publishCanceling"
           type="danger"
-          size="sm"
           @click="handleSwitchPublish(false)"
         >
           取消发布
         </VButton>
-        <VButton size="sm" type="default" @click="handleVisibleChange(false)">
+        <VButton :loading="saving" type="secondary" @click="handleSave">
+          保存
+        </VButton>
+        <VButton type="default" @click="handleVisibleChange(false)">
           关闭
         </VButton>
       </VSpace>

--- a/src/modules/contents/posts/components/PostSettingModal.vue
+++ b/src/modules/contents/posts/components/PostSettingModal.vue
@@ -15,7 +15,7 @@ const initialFormState: PostRequest = {
       template: "",
       cover: "",
       deleted: false,
-      published: false,
+      publish: false,
       publishTime: "",
       pinned: false,
       allowComment: true,
@@ -138,7 +138,7 @@ const handlePublishCanceling = async () => {
 
     // Update published spec = false
     const postToUpdate = cloneDeep(formState.value);
-    postToUpdate.post.spec.published = false;
+    postToUpdate.post.spec.publish = false;
     await apiClient.post.updateDraftPost({
       name: postToUpdate.post.metadata.name,
       postRequest: postToUpdate,

--- a/src/modules/contents/posts/components/PostSettingModal.vue
+++ b/src/modules/contents/posts/components/PostSettingModal.vue
@@ -1,73 +1,67 @@
 <script lang="ts" setup>
 import { VButton, VModal, VSpace, VTabItem, VTabs } from "@halo-dev/components";
 import { computed, ref, watchEffect } from "vue";
-import type { PostRequest } from "@halo-dev/api-client";
+import type { Post } from "@halo-dev/api-client";
 import cloneDeep from "lodash.clonedeep";
 import { apiClient } from "@/utils/api-client";
 import { v4 as uuid } from "uuid";
 import { useThemeCustomTemplates } from "@/modules/interface/themes/composables/use-theme";
+import { postLabels } from "@/constants/labels";
 
-const initialFormState: PostRequest = {
-  post: {
-    spec: {
-      title: "",
-      slug: "",
-      template: "",
-      cover: "",
-      deleted: false,
-      publish: false,
-      publishTime: "",
-      pinned: false,
-      allowComment: true,
-      visible: "PUBLIC",
-      version: 1,
-      priority: 0,
-      excerpt: {
-        autoGenerate: true,
-        raw: "",
-      },
-      categories: [],
-      tags: [],
-      htmlMetas: [],
+const initialFormState: Post = {
+  spec: {
+    title: "",
+    slug: "",
+    template: "",
+    cover: "",
+    deleted: false,
+    publish: false,
+    publishTime: "",
+    pinned: false,
+    allowComment: true,
+    visible: "PUBLIC",
+    version: 1,
+    priority: 0,
+    excerpt: {
+      autoGenerate: true,
+      raw: "",
     },
-    apiVersion: "content.halo.run/v1alpha1",
-    kind: "Post",
-    metadata: {
-      name: uuid(),
-    },
+    categories: [],
+    tags: [],
+    htmlMetas: [],
   },
-  content: {
-    raw: "",
-    content: "",
-    rawType: "HTML",
+  apiVersion: "content.halo.run/v1alpha1",
+  kind: "Post",
+  metadata: {
+    name: uuid(),
   },
 };
 
 const props = withDefaults(
   defineProps<{
     visible: boolean;
-    post?: PostRequest | null;
+    post?: Post;
   }>(),
   {
     visible: false,
-    post: null,
+    post: undefined,
   }
 );
 
 const emit = defineEmits<{
   (event: "update:visible", visible: boolean): void;
   (event: "close"): void;
-  (event: "saved", post: PostRequest): void;
+  (event: "saved", post: Post): void;
 }>();
 
 const activeTab = ref("general");
-const formState = ref<PostRequest>(cloneDeep(initialFormState));
+const formState = ref<Post>(cloneDeep(initialFormState));
 const saving = ref(false);
 const publishing = ref(false);
 const publishCanceling = ref(false);
 
 const isUpdateMode = computed(() => {
-  return !!formState.value.post.metadata.creationTimestamp;
+  return !!formState.value.metadata.creationTimestamp;
 });
 
 const handleVisibleChange = (visible: boolean) => {
@@ -81,23 +75,19 @@ const handleSave = async () => {
   try {
     saving.value = true;
 
-    // Set rendered content
-    formState.value.content.content = formState.value.content.raw;
+    const { data } = isUpdateMode.value
+      ? await apiClient.extension.post.updatecontentHaloRunV1alpha1Post({
+          name: formState.value.metadata.name,
+          post: formState.value,
+        })
+      : await apiClient.extension.post.createcontentHaloRunV1alpha1Post({
+          post: formState.value,
+        });
 
-    if (isUpdateMode.value) {
-      const { data } = await apiClient.post.updateDraftPost({
-        name: formState.value.post.metadata.name,
-        postRequest: formState.value,
-      });
-      formState.value.post = data;
-      emit("saved", formState.value);
-    } else {
-      const { data } = await apiClient.post.draftPost({
-        postRequest: formState.value,
-      });
-      formState.value.post = data;
-      emit("saved", formState.value);
-    }
+    formState.value = data;
+    emit("saved", data);
+
+    handleVisibleChange(false);
   } catch (e) {
     console.error("Failed to save post", e);
   } finally {
@@ -105,56 +95,34 @@ const handleSave = async () => {
   }
 };
 
-const handlePublish = async () => {
+const handleSwitchPublish = async (publish: boolean) => {
   try {
-    publishing.value = true;
+    if (publish) {
+      publishing.value = true;
+    } else {
+      publishCanceling.value = true;
+    }
 
-    // Save post
-    await handleSave();
-
-    // Get latest version post
-    const { data: latestData } =
-      await apiClient.extension.post.getcontentHaloRunV1alpha1Post({
-        name: formState.value.post.metadata.name,
+    const { data } =
+      await apiClient.extension.post.updatecontentHaloRunV1alpha1Post({
+        name: formState.value.metadata.name,
+        post: {
+          ...formState.value,
+          spec: {
+            ...formState.value.spec,
+            publish: publish,
+          },
+        },
       });
-    formState.value.post = latestData;
 
-    // Publish post
-    const { data } = await apiClient.post.publishPost({
-      name: formState.value.post.metadata.name,
-    });
-    formState.value.post = data;
-    emit("saved", formState.value);
+    formState.value = data;
+    emit("saved", data);
+
+    handleVisibleChange(false);
   } catch (e) {
     console.error("Failed to publish post", e);
   } finally {
     publishing.value = false;
-  }
-};
-
-const handlePublishCanceling = async () => {
-  try {
-    publishCanceling.value = true;
-
-    // Update published spec = false
-    const postToUpdate = cloneDeep(formState.value);
-    postToUpdate.post.spec.publish = false;
-    await apiClient.post.updateDraftPost({
-      name: postToUpdate.post.metadata.name,
-      postRequest: postToUpdate,
-    });
-
-    // Get latest version post
-    const { data: latestData } =
-      await apiClient.extension.post.getcontentHaloRunV1alpha1Post({
-        name: formState.value.post.metadata.name,
-      });
-
-    formState.value.post = latestData;
-    emit("saved", formState.value);
-  } catch (e) {
-    console.log("Failed to cancel publish", e);
-  } finally {
     publishCanceling.value = false;
   }
 };
@@ -190,33 +158,33 @@ const { templates } = useThemeCustomTemplates("post");
           type="form"
         >
           <FormKit
-            v-model="formState.post.spec.title"
+            v-model="formState.spec.title"
             label="标题"
             type="text"
             name="title"
             validation="required"
           ></FormKit>
           <FormKit
-            v-model="formState.post.spec.slug"
+            v-model="formState.spec.slug"
             label="别名"
             name="slug"
             type="text"
             validation="required"
           ></FormKit>
           <FormKit
-            v-model="formState.post.spec.categories"
+            v-model="formState.spec.categories"
             label="分类目录"
             name="categories"
             type="categoryCheckbox"
           />
           <FormKit
-            v-model="formState.post.spec.tags"
+            v-model="formState.spec.tags"
             label="标签"
             name="tags"
             type="tagCheckbox"
           />
           <FormKit
-            v-model="formState.post.spec.excerpt.autoGenerate"
+            v-model="formState.spec.excerpt.autoGenerate"
             :options="[
               { label: '是', value: true },
               { label: '否', value: false },
@@ -227,8 +195,8 @@ const { templates } = useThemeCustomTemplates("post");
           >
           </FormKit>
           <FormKit
-            v-if="!formState.post.spec.excerpt.autoGenerate"
-            v-model="formState.post.spec.excerpt.raw"
+            v-if="!formState.spec.excerpt.autoGenerate"
+            v-model="formState.spec.excerpt.raw"
             label="自定义摘要"
             name="raw"
             type="textarea"
@@ -245,7 +213,7 @@ const { templates } = useThemeCustomTemplates("post");
           type="form"
         >
           <FormKit
-            v-model="formState.post.spec.allowComment"
+            v-model="formState.spec.allowComment"
             :options="[
               { label: '是', value: true },
               { label: '否', value: false },
@@ -254,7 +222,7 @@ const { templates } = useThemeCustomTemplates("post");
             type="radio"
           ></FormKit>
           <FormKit
-            v-model="formState.post.spec.pinned"
+            v-model="formState.spec.pinned"
             :options="[
               { label: '是', value: true },
               { label: '否', value: false },
@@ -264,7 +232,7 @@ const { templates } = useThemeCustomTemplates("post");
             type="radio"
           ></FormKit>
           <FormKit
-            v-model="formState.post.spec.visible"
+            v-model="formState.spec.visible"
             :options="[
               { label: '公开', value: 'PUBLIC' },
               { label: '内部成员可访问', value: 'INTERNAL' },
@@ -275,19 +243,19 @@ const { templates } = useThemeCustomTemplates("post");
             type="select"
           ></FormKit>
           <FormKit
-            v-model="formState.post.spec.publishTime"
+            v-model="formState.spec.publishTime"
             label="发表时间"
             type="datetime-local"
           ></FormKit>
           <FormKit
-            v-model="formState.post.spec.template"
+            v-model="formState.spec.template"
             :options="templates"
             label="自定义模板"
             name="template"
             type="select"
           ></FormKit>
           <FormKit
-            v-model="formState.post.spec.cover"
+            v-model="formState.spec.cover"
             name="cover"
             label="封面图"
             type="attachment"
@@ -299,9 +267,15 @@ const { templates } = useThemeCustomTemplates("post");
 
     <template #footer>
       <VSpace>
-        <VButton :loading="publishing" type="secondary" @click="handlePublish">
+        <VButton
+          :loading="publishing"
+          type="secondary"
+          @click="handleSwitchPublish(true)"
+        >
           {{
-            formState.post.status?.phase === "PUBLISHED" ? "重新发布" : "发布"
+            formState.metadata.labels?.[postLabels.PUBLISHED] === "true"
+              ? "重新发布"
+              : "发布"
           }}
         </VButton>
         <VButton
@@ -310,14 +284,14 @@ const { templates } = useThemeCustomTemplates("post");
           type="secondary"
           @click="handleSave"
         >
-          仅保存
+          保存
         </VButton>
         <VButton
-          v-if="formState.post.status?.phase === 'PUBLISHED'"
+          v-if="formState.status?.phase === 'PUBLISHED'"
           :loading="publishCanceling"
           type="danger"
           size="sm"
-          @click="handlePublishCanceling"
+          @click="handleSwitchPublish(false)"
         >
           取消发布
         </VButton>

--- a/src/modules/dashboard/widgets/RecentPublishedWidget.vue
+++ b/src/modules/dashboard/widgets/RecentPublishedWidget.vue
@@ -4,14 +4,16 @@ import { onMounted, ref } from "vue";
 import type { ListedPost } from "@halo-dev/api-client";
 import { apiClient } from "@/utils/api-client";
 import { formatDatetime } from "@/utils/date";
+import { postLabels } from "@/constants/labels";
 
 const posts = ref<ListedPost[]>([] as ListedPost[]);
 
 const handleFetchPosts = async () => {
   try {
     const { data } = await apiClient.post.listPosts({
+      labelSelector: [`${postLabels.PUBLISHED}=true`],
       sort: "PUBLISH_TIME",
-      publishPhase: "PUBLISHED",
+      sortOrder: true,
       page: 1,
       size: 10,
     });

--- a/src/modules/dashboard/widgets/RecentPublishedWidget.vue
+++ b/src/modules/dashboard/widgets/RecentPublishedWidget.vue
@@ -13,7 +13,7 @@ const handleFetchPosts = async () => {
     const { data } = await apiClient.post.listPosts({
       labelSelector: [`${postLabels.PUBLISHED}=true`],
       sort: "PUBLISH_TIME",
-      sortOrder: true,
+      sortOrder: false,
       page: 1,
       size: 10,
     });

--- a/src/views/system/Setup.vue
+++ b/src/views/system/Setup.vue
@@ -50,24 +50,10 @@ const handleSubmit = async () => {
     });
     await apiClient.post.draftPost({ postRequest: post as PostRequest });
 
-    try {
-      await apiClient.post.publishPost({ name: post.post.metadata.name });
-    } catch (error) {
-      console.error("Failed to publish post", error);
-    }
-
     // Create singlePage
     await apiClient.singlePage.draftSinglePage({
       singlePageRequest: singlePage as SinglePageRequest,
     });
-
-    try {
-      await apiClient.singlePage.publishSinglePage({
-        name: singlePage.page.metadata.name,
-      });
-    } catch (error) {
-      console.error("Failed to publish singlePage", error);
-    }
 
     // Create menu and menu items
     const menuItemPromises = menuItems.map((item) => {

--- a/src/views/system/setup-data/post.json
+++ b/src/views/system/setup-data/post.json
@@ -6,7 +6,7 @@
       "template": "",
       "cover": "",
       "deleted": false,
-      "published": false,
+      "publish": true,
       "publishTime": "",
       "pinned": false,
       "allowComment": true,

--- a/src/views/system/setup-data/singlePage.json
+++ b/src/views/system/setup-data/singlePage.json
@@ -6,7 +6,7 @@
       "template": "",
       "cover": "",
       "deleted": false,
-      "published": false,
+      "publish": true,
       "publishTime": "",
       "pinned": false,
       "allowComment": true,


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/milestone 2.0

#### What this PR does / why we need it:

重构文章和自定义页面的发布流程。

Ref https://github.com/halo-dev/halo/pull/2659

1. 修改文章、自定义页面标识发布状态的字段名。
2. 修改初始化页面中创建文章和自定义页面的逻辑，取消使用发布接口，改为直接将 `spec.publish` 设置为 `true`
3. 列表支持检测发布状态。

#### Special notes for your reviewer:

测试方式：

1. Halo 需要切换到 https://github.com/halo-dev/halo/pull/2659 分支。
2. Console 需要 `pnpm install && pnpm build:packages`
3. 测试文章和自定义页面的发布、保存等流程。需要完整测试整个流程。

#### Does this PR introduce a user-facing change?

```release-note
None
```
