### PR TITLE
fix: the problem of incorrect hint of opening developer option

### DIFF
--- a/src/components/Tools/Logo.vue
+++ b/src/components/Tools/Logo.vue
@@ -44,13 +44,13 @@ export default {
         }
         return
       }
-      if (this.clickCount >= 5) {
-        if (this.options.developer_mode) {
-          this.$message.info(`当前已启用开发者选项！`)
-          this.clickCount = 0
-        } else {
-          this.$message.info(`再点击 ${10 - this.clickCount} 次即可启用开发者选项！`)
-        }
+      if (this.options.developer_mode) {
+        this.$message.info(`当前已启用开发者选项！`)
+        this.clickCount = 0
+      } else if (this.clickCount < 10) {
+        this.$message.info(`再点击 ${10 - this.clickCount} 次即可启用开发者选项！`)
+      } else {
+        this.$message.info('正在启用开发者选项！')
       }
     }, 200)
   }

--- a/src/components/Tools/Logo.vue
+++ b/src/components/Tools/Logo.vue
@@ -31,10 +31,15 @@ export default {
     ...mapActions(['refreshOptionsCache']),
     onLogoClick: throttle(async function () {
       this.clickCount++
+      if (this.options.developer_mode) {
+        this.$message.info(`当前已启用开发者选项！`)
+        this.clickCount = 0
+      } else if (this.clickCount < 10) {
+        this.$message.info(`再点击 ${10 - this.clickCount} 次即可启用开发者选项！`)
+      }
       if (this.clickCount === 10) {
         try {
           await apiClient.option.saveMapView({ developer_mode: true })
-
           await this.refreshOptionsCache()
           this.$message.success(`开发者选项已启用！`)
           this.clickCount = 0
@@ -43,12 +48,6 @@ export default {
           this.$log.error(e)
         }
         return
-      }
-      if (this.options.developer_mode) {
-        this.$message.info(`当前已启用开发者选项！`)
-        this.clickCount = 0
-      } else if (this.clickCount < 10) {
-        this.$message.info(`再点击 ${10 - this.clickCount} 次即可启用开发者选项！`)
       } else {
         this.$message.info('正在启用开发者选项！')
       }

--- a/src/components/Tools/Logo.vue
+++ b/src/components/Tools/Logo.vue
@@ -36,8 +36,7 @@ export default {
         this.clickCount = 0
       } else if (this.clickCount < 10) {
         this.$message.info(`再点击 ${10 - this.clickCount} 次即可启用开发者选项！`)
-      }
-      if (this.clickCount === 10) {
+      } else if (this.clickCount === 10) {
         try {
           await apiClient.option.saveMapView({ developer_mode: true })
           await this.refreshOptionsCache()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. 如果这是你的第一次，请阅读我们的贡献指南：<https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>。
1. If this is your first time, please read our contributor guidelines: <https://github.com/halo-dev/halo/blob/master/CONTRIBUTING.md>.
2. 请根据你解决问题的类型为 Pull Request 添加合适的标签。
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. 请确保你已经添加并运行了适当的测试。
3. Ensure you have added or ran the appropriate tests for your PR.
-->

#### What type of PR is this?
/kind bug
<!--
添加其中一个类别：
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind optimization
适当添加其中一个或多个类别（可选）：
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
PR 合并时自动关闭 issue。
Automatically closes linked issue when PR is merged.
用法：`Fixes #<issue 号>`，或者 `Fixes (粘贴 issue 完整链接)`
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes (https://github.com/halo-dev/halo/issues/1951)

```js
// 判断是否为开发者模式，计数是否小于10，大于10说明正在请求后台。
      if (this.options.developer_mode) {
        this.$message.info(`当前已启用开发者选项！`)
        this.clickCount = 0
      } else if (this.clickCount < 10) {
        this.$message.info(`再点击 ${10 - this.clickCount} 次即可启用开发者选项！`)
      } else if (this.clickCount === 10){
           //处理开启逻辑
      }else {
             this.$message.info('正在启用开发者选项！')
       }
```

#### Screenshots:

<!--
如果此 PR 有 UI 的改动，最好截图说明这个 PR 的改动。
If there are UI changes to this PR, it is best to take a screenshot to illustrate the changes to this PR.
eg.
Before:
![screenshot-before](https://user-images.githubusercontent.com/screenshot.png)
After:
![screenshot-after](https://user-images.githubusercontent.com/screenshot.png)
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
如果当前 Pull Request 的修改不会造成用户侧的任何变更，在 `release-note` 代码块儿中填写 `NONE`。
否则请填写用户侧能够理解的 Release Note。如果当前 Pull Request 包含破坏性更新（Break Change），
Release Note 需要以 `action required` 开头。
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
