### PR TITLE
feat: post editor page supports the parameter of returnToView

### DIFF
--- a/src/modules/contents/pages/SinglePageEditor.vue
+++ b/src/modules/contents/pages/SinglePageEditor.vue
@@ -108,7 +108,7 @@ const handleSave = async () => {
   }
 };
 
-const returnTo = useRouteQuery<string>("returnTo");
+const returnToView = useRouteQuery<string>("returnToView");
 
 const handlePublish = async () => {
   try {
@@ -119,6 +119,7 @@ const handlePublish = async () => {
 
     if (isUpdateMode.value) {
       const { name: singlePageName } = formState.value.page.metadata;
+      const { permalink } = formState.value.page.status || {};
 
       await apiClient.singlePage.updateSinglePageContent({
         name: singlePageName,
@@ -128,6 +129,12 @@ const handlePublish = async () => {
       await apiClient.singlePage.publishSinglePage({
         name: singlePageName,
       });
+
+      if (returnToView.value && permalink) {
+        window.location.href = permalink;
+      } else {
+        router.push({ name: "SinglePages" });
+      }
     } else {
       formState.value.page.spec.publish = true;
       await apiClient.singlePage.draftSinglePage({
@@ -136,12 +143,6 @@ const handlePublish = async () => {
     }
 
     Toast.success("发布成功");
-
-    if (returnTo.value) {
-      window.location.href = returnTo.value;
-    } else {
-      router.push({ name: "SinglePages" });
-    }
   } catch (error) {
     console.error("Failed to publish single page", error);
     Toast.error("发布失败，请重试");

--- a/src/modules/contents/pages/SinglePageEditor.vue
+++ b/src/modules/contents/pages/SinglePageEditor.vue
@@ -108,6 +108,8 @@ const handleSave = async () => {
   }
 };
 
+const returnTo = useRouteQuery<string>("returnTo");
+
 const handlePublish = async () => {
   try {
     publishing.value = true;
@@ -135,7 +137,11 @@ const handlePublish = async () => {
 
     Toast.success("发布成功");
 
-    router.push({ name: "SinglePages" });
+    if (returnTo.value) {
+      window.location.href = returnTo.value;
+    } else {
+      router.push({ name: "SinglePages" });
+    }
   } catch (error) {
     console.error("Failed to publish single page", error);
     Toast.error("发布失败，请重试");

--- a/src/modules/contents/posts/PostEditor.vue
+++ b/src/modules/contents/posts/PostEditor.vue
@@ -109,7 +109,7 @@ const handleSave = async () => {
   }
 };
 
-const returnTo = useRouteQuery<string>("returnTo");
+const returnToView = useRouteQuery<string>("returnToView");
 
 const handlePublish = async () => {
   try {
@@ -120,6 +120,7 @@ const handlePublish = async () => {
 
     if (isUpdateMode.value) {
       const { name: postName } = formState.value.post.metadata;
+      const { permalink } = formState.value.post.status || {};
 
       await apiClient.post.updatePostContent({
         name: postName,
@@ -129,6 +130,12 @@ const handlePublish = async () => {
       await apiClient.post.publishPost({
         name: postName,
       });
+
+      if (returnToView.value === "true" && permalink) {
+        window.location.href = permalink;
+      } else {
+        router.push({ name: "Posts" });
+      }
     } else {
       const { data } = await apiClient.post.draftPost({
         postRequest: formState.value,
@@ -140,12 +147,6 @@ const handlePublish = async () => {
     }
 
     Toast.success("发布成功", { duration: 2000 });
-
-    if (returnTo.value) {
-      window.location.href = returnTo.value;
-    } else {
-      router.push({ name: "Posts" });
-    }
   } catch (error) {
     console.error("Failed to publish post", error);
     Toast.error("发布失败，请重试");

--- a/src/modules/contents/posts/PostEditor.vue
+++ b/src/modules/contents/posts/PostEditor.vue
@@ -109,6 +109,8 @@ const handleSave = async () => {
   }
 };
 
+const returnTo = useRouteQuery<string>("returnTo");
+
 const handlePublish = async () => {
   try {
     publishing.value = true;
@@ -139,7 +141,11 @@ const handlePublish = async () => {
 
     Toast.success("发布成功", { duration: 2000 });
 
-    router.push({ name: "Posts" });
+    if (returnTo.value) {
+      window.location.href = returnTo.value;
+    } else {
+      router.push({ name: "Posts" });
+    }
   } catch (error) {
     console.error("Failed to publish post", error);
     Toast.error("发布失败，请重试");


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/milestone 2.0

#### What this PR does / why we need it:

文章和独立页面的编辑页面支持 `returnTo` 参数，用于指定发布完成之后的跳转地址。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2724

#### Special notes for your reviewer:

/cc @halo-dev/sig-halo-console 

测试方式：

1. 选择任意文章进入编辑页面。
2. 在地址栏添加 `&returnTo=http://localhost:8090`
3. 发布文章，观察是否跳转到了 `http://localhost:8090`

#### Does this PR introduce a user-facing change?

```release-note
文章和独立页面的编辑页面支持 `returnTo` 参数。
```
