### PR TITLE
Change package version to 1.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halo-admin",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "author": "halo-dev",
   "description": "Halo admin client.",
   "repository": {


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR mainly changes version to 1.5.6 in package.json to prepare for the release of 1.5.6.

#### Does this PR introduce a user-facing change?

```release-note
None
```
