### PR TITLE
feat: add query attachments by ungrouped parameter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@formkit/themes": "^1.0.0-beta.11",
     "@formkit/vue": "^1.0.0-beta.11",
     "@formkit/utils": "^1.0.0-beta.11",
-    "@halo-dev/api-client": "^0.0.50",
+    "@halo-dev/api-client": "^0.0.51",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
     "@halo-dev/richtext-editor": "^0.0.0-alpha.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@formkit/themes': ^1.0.0-beta.11
       '@formkit/utils': ^1.0.0-beta.11
       '@formkit/vue': ^1.0.0-beta.11
-      '@halo-dev/api-client': ^0.0.50
+      '@halo-dev/api-client': ^0.0.51
       '@halo-dev/components': workspace:*
       '@halo-dev/console-shared': workspace:*
       '@halo-dev/richtext-editor': ^0.0.0-alpha.11
@@ -104,7 +104,7 @@ importers:
       '@formkit/themes': 1.0.0-beta.12-e579559_tailwindcss@3.2.4
       '@formkit/utils': 1.0.0-beta.12-e579559
       '@formkit/vue': 1.0.0-beta.12-e579559_ior6jr3fpijijuwpr34w2i25va
-      '@halo-dev/api-client': 0.0.50
+      '@halo-dev/api-client': 0.0.51
       '@halo-dev/components': link:packages/components
       '@halo-dev/console-shared': link:packages/shared
       '@halo-dev/richtext-editor': 0.0.0-alpha.11_vue@3.2.45
@@ -1970,8 +1970,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/api-client/0.0.50:
-    resolution: {integrity: sha512-/bf/zv/27Pk2dpyozKeEjFkNy5P5ecGX2064WA2oQVHV8sK0UeCRrzDKQ/bIHrHJWaP9aBAN29fE9ocBXoJMeg==}
+  /@halo-dev/api-client/0.0.51:
+    resolution: {integrity: sha512-kvwhTogmVVLNwfbAVSNUC+pYt7YXn+eaOD0/5N11BmJ+2pHQUSUKjtPwOF+U+KkQ8hRGmFxHD2XvnrcCOr4XHQ==}
     dev: false
 
   /@halo-dev/richtext-editor/0.0.0-alpha.11_vue@3.2.45:

--- a/src/modules/contents/attachments/AttachmentList.vue
+++ b/src/modules/contents/attachments/AttachmentList.vue
@@ -208,12 +208,16 @@ const onDetailModalClose = () => {
   selectedAttachment.value = undefined;
   nameQuery.value = undefined;
   nameQueryAttachment.value = undefined;
-  handleFetchAttachments();
+  setTimeout(() => {
+    handleFetchAttachments();
+  }, 200);
 };
 
 const onUploadModalClose = () => {
   routeQueryAction.value = undefined;
-  handleFetchAttachments();
+  setTimeout(() => {
+    handleFetchAttachments();
+  }, 200);
 };
 
 const onGroupChange = () => {

--- a/src/modules/contents/attachments/components/AttachmentGroupList.vue
+++ b/src/modules/contents/attachments/components/AttachmentGroupList.vue
@@ -57,7 +57,7 @@ const defaultGroups: Group[] = [
     apiVersion: "",
     kind: "",
     metadata: {
-      name: "none",
+      name: "ungrouped",
     },
   },
 ];
@@ -68,7 +68,7 @@ const groupToUpdate = ref<Group | null>(null);
 const loading = ref<boolean>(false);
 const editingModal = ref(false);
 
-const routeQuery = useRouteQuery("group");
+const routeQuery = useRouteQuery<string>("group");
 
 const handleSelectGroup = (group: Group) => {
   emit("update:selectedGroup", group);
@@ -166,7 +166,8 @@ const handleDeleteWithAttachments = (group: Group) => {
 watch(
   () => groups.value.length,
   () => {
-    const groupIndex = groups.value.findIndex(
+    const allGroups = [...defaultGroups, ...groups.value];
+    const groupIndex = allGroups.findIndex(
       (group) => group.metadata.name === routeQuery.value
     );
 
@@ -186,8 +187,8 @@ onMounted(async () => {
     );
     if (group) {
       handleSelectGroup(group);
+      return;
     }
-    return;
   }
 
   handleSelectGroup(defaultGroups[0]);

--- a/src/modules/contents/attachments/composables/use-attachment.ts
+++ b/src/modules/contents/attachments/composables/use-attachment.ts
@@ -82,6 +82,7 @@ export function useAttachmentControl(filterOptions?: {
         policy: policy?.value?.metadata.name,
         displayName: keyword?.value,
         group: group?.value?.metadata.name,
+        ungrouped: group?.value?.metadata.name === "ungrouped",
         uploadedBy: user?.value?.metadata.name,
         page: attachments.value.page,
         size: attachments.value.size,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/milestone 2.0

#### What this PR does / why we need it:

附件管理支持通过参数筛选出未分组的附件。适配 https://github.com/halo-dev/halo/pull/2752

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2451

#### Special notes for your reviewer:

/cc @halo-dev/sig-halo-console 

测试方式：

1. Halo 需要切换到 https://github.com/halo-dev/halo/pull/2752 分支。
2. Console 需要 `pnpm install`
3. 上传若干未分组附件，然后切换到未分组的标签，检查是否查询正确。
4. 将部分附件移动至某个分组，在切换到未分组的标签，检查附件是否正确。

#### Does this PR introduce a user-facing change?


```release-note
附件管理支持未分组的筛选条件。
```
