### PR TITLE
perf: formkit post input type only queries the available

### DIFF
--- a/src/formkit/inputs/post-select.ts
+++ b/src/formkit/inputs/post-select.ts
@@ -1,16 +1,21 @@
+import { postLabels } from "@/constants/labels";
 import { apiClient } from "@/utils/api-client";
 import type { FormKitNode, FormKitTypeDefinition } from "@formkit/core";
 import { select, selects, defaultIcon } from "@formkit/inputs";
 
 function optionsHandler(node: FormKitNode) {
   node.on("created", async () => {
-    const { data } =
-      await apiClient.extension.post.listcontentHaloRunV1alpha1Post();
+    const { data } = await apiClient.post.listPosts({
+      labelSelector: [
+        `${postLabels.DELETED}=false`,
+        `${postLabels.PUBLISHED}=true`,
+      ],
+    });
 
     node.props.options = data.items.map((post) => {
       return {
-        value: post.metadata.name,
-        label: post.spec.title,
+        value: post.post.metadata.name,
+        label: post.post.spec.title,
       };
     });
   });

--- a/src/formkit/inputs/singlePage-select.ts
+++ b/src/formkit/inputs/singlePage-select.ts
@@ -1,16 +1,21 @@
+import { singlePageLabels } from "@/constants/labels";
 import { apiClient } from "@/utils/api-client";
 import type { FormKitNode, FormKitTypeDefinition } from "@formkit/core";
 import { select, selects, defaultIcon } from "@formkit/inputs";
 
 function optionsHandler(node: FormKitNode) {
   node.on("created", async () => {
-    const { data } =
-      await apiClient.extension.singlePage.listcontentHaloRunV1alpha1SinglePage();
+    const { data } = await apiClient.singlePage.listSinglePages({
+      labelSelector: [
+        `${singlePageLabels.DELETED}=false`,
+        `${singlePageLabels.PUBLISHED}=true`,
+      ],
+    });
 
     node.props.options = data.items.map((singlePage) => {
       return {
-        value: singlePage.metadata.name,
-        label: singlePage.spec.title,
+        value: singlePage.page.metadata.name,
+        label: singlePage.page.spec.title,
       };
     });
   });


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/milestone 2.0.0-rc.2

#### What this PR does / why we need it:

FormKit 的文章和自定义页面选择器仅查询可用的文章或自定义页面。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2790

#### Special notes for your reviewer:

测试方式：

1. 创建若干文章和自定义页面，然后删除一部分，再将一部分设置为未发布。
2. 进入菜单管理新建菜单项，选择文章或者自定义页面类型。
3. 检查是否包含被删除或者未发布的文章和自定义页面。

#### Does this PR introduce a user-facing change?


```release-note
None
```
