### PR TITLE
refactor: remove the option to make the post internally accessible to members

### DIFF
--- a/src/modules/contents/pages/SinglePageList.vue
+++ b/src/modules/contents/pages/SinglePageList.vue
@@ -311,10 +311,11 @@ const VisibleItems: VisibleItem[] = [
     label: "公开",
     value: "PUBLIC",
   },
-  {
-    label: "内部成员可访问",
-    value: "INTERNAL",
-  },
+  // TODO: 支持内部成员可访问
+  // {
+  //   label: "内部成员可访问",
+  //   value: "INTERNAL",
+  // },
   {
     label: "私有",
     value: "PRIVATE",
@@ -742,8 +743,9 @@ function handleClearFilters() {
                     v-tooltip="`私有访问`"
                     class="cursor-pointer text-sm transition-all hover:text-blue-600"
                   />
+                  <!-- TODO: 支持内部成员可访问 -->
                   <IconTeam
-                    v-if="singlePage.page.spec.visible === 'INTERNAL'"
+                    v-if="false"
                     v-tooltip="`内部成员可访问`"
                     class="cursor-pointer text-sm transition-all hover:text-blue-600"
                   />

--- a/src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -270,7 +270,6 @@ const onPublishTimeChange = (value: string) => {
             v-model="formState.spec.visible"
             :options="[
               { label: '公开', value: 'PUBLIC' },
-              { label: '内部成员可访问', value: 'INTERNAL' },
               { label: '私有', value: 'PRIVATE' },
             ]"
             label="可见性"

--- a/src/modules/contents/posts/PostList.vue
+++ b/src/modules/contents/posts/PostList.vue
@@ -324,10 +324,11 @@ const VisibleItems: VisibleItem[] = [
     label: "公开",
     value: "PUBLIC",
   },
-  {
-    label: "内部成员可访问",
-    value: "INTERNAL",
-  },
+  // TODO: 支持内部成员可访问
+  // {
+  //   label: "内部成员可访问",
+  //   value: "INTERNAL",
+  // },
   {
     label: "私有",
     value: "PRIVATE",
@@ -865,8 +866,9 @@ const hasFilters = computed(() => {
                       v-tooltip="`私有访问`"
                       class="cursor-pointer text-sm transition-all hover:text-blue-600"
                     />
+                    <!-- TODO: 支持内部成员可访问 -->
                     <IconTeam
-                      v-if="post.post.spec.visible === 'INTERNAL'"
+                      v-if="false"
                       v-tooltip="`内部成员可访问`"
                       class="cursor-pointer text-sm transition-all hover:text-blue-600"
                     />

--- a/src/modules/contents/posts/components/PostSettingModal.vue
+++ b/src/modules/contents/posts/components/PostSettingModal.vue
@@ -272,7 +272,6 @@ const onPublishTimeChange = (value: string) => {
             v-model="formState.spec.visible"
             :options="[
               { label: '公开', value: 'PUBLIC' },
-              { label: '内部成员可访问', value: 'INTERNAL' },
               { label: '私有', value: 'PRIVATE' },
             ]"
             label="可见性"


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/milestone 2.0

#### What this PR does / why we need it:

移除文章设置中内部成员可访问的选项，目前后端没有支持。

#### Does this PR introduce a user-facing change?


```release-note
None
```
