### PR TITLE
fix: the issue that custom link type menu items cannot be saved normally

### DIFF
--- a/src/modules/interface/menus/components/MenuItemEditingModal.vue
+++ b/src/modules/interface/menus/components/MenuItemEditingModal.vue
@@ -60,11 +60,13 @@ const handleSaveMenuItem = async () => {
       (ref) => ref.ref?.kind === selectedRefKind.value
     );
 
-    if (menuItemRef) {
+    if (menuItemRef?.ref) {
       formState.value.spec.targetRef = {
         ...menuItemRef.ref,
         name: selectedRefName.value,
       };
+      formState.value.spec.displayName = undefined;
+      formState.value.spec.href = undefined;
     }
 
     if (isUpdateMode.value) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/milestone 2.0.1

#### What this PR does / why we need it:

修复创建菜单项的时候，自定义链接类型的菜单项无法正常保存名称和链接的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2816

#### Special notes for your reviewer:

测试方式：

1. 创建若干自定义类型的菜单项。
2. 检查是否成功保存了名称和连接。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端无法正常创建自定义链接类型菜单项的问题。
```
