### PR TITLE
feat: refining the logic of user roles

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,0 +1,1 @@
+export const SUPER_ROLE_NAME = "super-role";

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -6,6 +6,7 @@ export enum pluginLabels {
 // role
 export enum roleLabels {
   TEMPLATE = "halo.run/role-template",
+  SYSTEM_RESERVED = "rbac.authorization.halo.run/system-reserved",
 }
 
 // post

--- a/src/modules/system/roles/composables/use-role.ts
+++ b/src/modules/system/roles/composables/use-role.ts
@@ -97,14 +97,18 @@ export function useRoleForm(): useRoleFormReturn {
     try {
       saving.value = true;
       if (isUpdateMode.value) {
-        await apiClient.extension.role.updatev1alpha1Role({
+        const { data } = await apiClient.extension.role.updatev1alpha1Role({
           name: formState.value.metadata.name,
           role: formState.value,
         });
+
+        formState.value = data;
       } else {
-        await apiClient.extension.role.createv1alpha1Role({
+        const { data } = await apiClient.extension.role.createv1alpha1Role({
           role: formState.value,
         });
+
+        formState.value = data;
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement
/milestone 2.0.1

#### What this PR does / why we need it:

完善用户角色的相关逻辑。适配 https://github.com/halo-dev/halo/pull/2865

1. 支持标识是否是系统保留角色。
2. 根据是否是系统保留角色，禁用修改和删除的操作。
3. 支持判断是否是超级管理员，如果是，默认勾选所有权限。
4. 优化 `包含 N 个权限` 文案的逻辑，超级管理员为 `包含所有权限`。
5. 优化 `基于此角色创建` 的逻辑，判断是否为超级管理员，如果是，需要设置所有角色模板到创建表单。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2844

#### Screenshots:

<img width="1663" alt="image" src="https://user-images.githubusercontent.com/21301288/205965292-b8f8e556-e06b-422b-b0be-8d87a68f18be.png">
<img width="1661" alt="image" src="https://user-images.githubusercontent.com/21301288/205965333-1491c023-6726-4cdd-b970-d868a30f3296.png">

#### Special notes for your reviewer:

测试方式：

1. Halo 需要切换到 https://github.com/halo-dev/halo/pull/2865 分支。
2. 测试角色相关的所有功能。

#### Does this PR introduce a user-facing change?


```release-note
完善 Console 端用户角色的相关逻辑
```
