### PR TITLE
fix: plugin failed to get settings when plugin is stopped

### DIFF
--- a/src/modules/system/plugins/layouts/PluginLayout.vue
+++ b/src/modules/system/plugins/layouts/PluginLayout.vue
@@ -25,6 +25,7 @@ import BasicLayout from "@/layouts/BasicLayout.vue";
 import type { Ref } from "vue";
 import type { Plugin, SettingForm } from "@halo-dev/api-client";
 import { usePermission } from "@/utils/permission";
+import { usePluginLifeCycle } from "../composables/use-plugin";
 
 const { currentUserHasPermission } = usePermission();
 
@@ -59,6 +60,8 @@ provide<Ref<string | undefined>>("activeTab", activeTab);
 
 const settingName = computed(() => plugin.value?.spec.settingName);
 const configMapName = computed(() => plugin.value?.spec.configMapName);
+
+const { isStarted } = usePluginLifeCycle(plugin);
 
 const { setting, handleFetchSettings } = useSettingForm(
   settingName,
@@ -112,7 +115,9 @@ onMounted(async () => {
     return;
   }
 
-  await handleFetchSettings();
+  if (isStarted.value) {
+    await handleFetchSettings();
+  }
 
   tabs.value = cloneDeep(initialTabs);
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/milestone 2.0.1

#### What this PR does / why we need it:

修复插件停止时，仍然获取设置选项导致提示失败的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2866

#### Special notes for your reviewer:

测试方式：

1. 安装一个插件，将其停止之后检查是否有获取 setting 的请求以及页面上是否有提示。

#### Does this PR introduce a user-facing change?

```release-note
修复在 Console 端停止插件时，仍然获取设置选项导致显示失败提示的问题。
```
