### PR TITLE
fix: cannot save post when the publishTime is blank

### DIFF
--- a/src/modules/contents/pages/components/SinglePageSettingModal.vue
+++ b/src/modules/contents/pages/components/SinglePageSettingModal.vue
@@ -177,7 +177,7 @@ const publishTime = computed(() => {
 });
 
 const onPublishTimeChange = (value: string) => {
-  formState.value.spec.publishTime = toISOString(value);
+  formState.value.spec.publishTime = value ? toISOString(value) : undefined;
 };
 </script>
 

--- a/src/modules/contents/posts/components/PostSettingModal.vue
+++ b/src/modules/contents/posts/components/PostSettingModal.vue
@@ -169,7 +169,7 @@ const publishTime = computed(() => {
 });
 
 const onPublishTimeChange = (value: string) => {
-  formState.value.spec.publishTime = toISOString(value);
+  formState.value.spec.publishTime = value ? toISOString(value) : undefined;
 };
 </script>
 <template>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

修复当文章设置中的发布时间为空字符串时，无法保存的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2906

#### Special notes for your reviewer:

测试方式：

1. 进入新建文章页面。
2. 点击右上角发布按钮，填写必要的标题和别名，然后点击保存。
3. 点击右上角设置按钮，切换到高级设置，再次点击保存。
4. 观察是否正常保存。

#### Does this PR introduce a user-facing change?

```release-note
修复 Console 端文章设置中的发布时间为空字符串时，无法保存的问题。
```
