### PR TITLE
chore: bump @halo-dev/richtext-editor to fix iframe display and add HTML syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@halo-dev/api-client": "^0.0.60",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
-    "@halo-dev/richtext-editor": "^0.0.0-alpha.16",
+    "@halo-dev/richtext-editor": "^0.0.0-alpha.17",
     "@tiptap/extension-character-count": "^2.0.0-beta.202",
     "@uppy/core": "^3.0.4",
     "@uppy/dashboard": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
       '@halo-dev/api-client': ^0.0.60
       '@halo-dev/components': workspace:*
       '@halo-dev/console-shared': workspace:*
-      '@halo-dev/richtext-editor': ^0.0.0-alpha.16
+      '@halo-dev/richtext-editor': ^0.0.0-alpha.17
       '@iconify-json/mdi': ^1.1.36
       '@iconify-json/vscode-icons': ^1.1.16
       '@rushstack/eslint-patch': ^1.2.0
@@ -110,7 +110,7 @@ importers:
       '@halo-dev/api-client': 0.0.60
       '@halo-dev/components': link:packages/components
       '@halo-dev/console-shared': link:packages/shared
-      '@halo-dev/richtext-editor': 0.0.0-alpha.16_vue@3.2.45
+      '@halo-dev/richtext-editor': 0.0.0-alpha.17_vue@3.2.45
       '@tiptap/extension-character-count': 2.0.0-beta.202
       '@uppy/core': 3.0.4
       '@uppy/dashboard': 3.2.0_@uppy+core@3.0.4
@@ -1972,8 +1972,8 @@ packages:
     resolution: {integrity: sha512-HAmJ1BDZxHj2Xp41oNOqZG/1vaR6r4EbBAUQ7ayvUY8SGJMHtJD9dyhCn7k23q6G7FmzFKFNGxajovsjBEM+yg==}
     dev: false
 
-  /@halo-dev/richtext-editor/0.0.0-alpha.16_vue@3.2.45:
-    resolution: {integrity: sha512-MW0KCYT6UGg2zOh0kryGEz+IKLzo/onUTbAYCkiMX4YaQ1mIOoBU+ILaa0YOL2FmDyCxXst/UoSKdUvZu+Qieg==}
+  /@halo-dev/richtext-editor/0.0.0-alpha.17_vue@3.2.45:
+    resolution: {integrity: sha512-q9xVHdUdgsXFT6nj31DKNyhR/Flh/jHcepOC/FUlWf58yoZ7i2+6YeTcrcxeVV/DBKlvVXVvQ1As6zPrCY7+Bg==}
     peerDependencies:
       vue: ^3.2.37
     dependencies:
@@ -2015,6 +2015,7 @@ packages:
       '@tiptap/vue-3': 2.0.0-beta.202_jtnhdqyx7clarsezcvtuxgjsq4
       '@vueuse/core': 9.6.0_vue@3.2.45
       floating-vue: 2.0.0-beta.20_vue@3.2.45
+      highlight.js: 11.6.0
       katex: 0.16.3
       lowlight: 2.7.0
       tippy.js: 6.3.7


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

升级 `@halo-dev/richtext-editor` 版本，解决以下问题：

1. 修复嵌入网页不会回显的问题。 https://github.com/halo-sigs/richtext-editor/commit/c8cfe8f7b19441c80bf46c55d90356f4b2ab3c1e
2. 添加 HTML 语法的代码块高亮。 https://github.com/halo-sigs/richtext-editor/commit/8d27ae81eec5eb047daaba7e832ca2f5f62075de

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2924
Fixes https://github.com/halo-dev/halo/issues/2913

#### Special notes for your reviewer:

测试方式：

1. 需要 `pnpm install`
2. 插件编辑器的代码块是否有 HTML 语言选项。
3. 插入一个嵌入网页的编辑块，保存文章之后再次进入编辑页面，检查加载是否正常。

#### Does this PR introduce a user-facing change?

```release-note
None
```
