### PR TITLE
Differentiate the title of adding and editing menu and menu item

### DIFF
--- a/src/modules/interface/menus/components/MenuEditingModal.vue
+++ b/src/modules/interface/menus/components/MenuEditingModal.vue
@@ -45,6 +45,10 @@ const isUpdateMode = computed(() => {
   return !!formState.value.metadata.creationTimestamp;
 });
 
+const modalTitle = computed(() => {
+  return isUpdateMode.value ? "编辑菜单" : "新增菜单";
+});
+
 const handleCreateMenu = async () => {
   try {
     saving.value = true;
@@ -107,7 +111,7 @@ watch(
   <VModal
     :visible="visible"
     :width="500"
-    title="编辑菜单"
+    :title="modalTitle"
     @update:visible="onVisibleChange"
   >
     <FormKit

--- a/src/modules/interface/menus/components/MenuItemEditingModal.vue
+++ b/src/modules/interface/menus/components/MenuItemEditingModal.vue
@@ -52,6 +52,10 @@ const isUpdateMode = computed(() => {
   return !!formState.value.metadata.creationTimestamp;
 });
 
+const modalTitle = computed(() => {
+  return isUpdateMode.value ? "编辑菜单项" : "新增菜单项";
+});
+
 const handleSaveMenuItem = async () => {
   try {
     saving.value = true;
@@ -240,7 +244,7 @@ const onMenuItemSourceChange = () => {
   <VModal
     :visible="visible"
     :width="500"
-    title="编辑菜单项"
+    :title="modalTitle"
     @update:visible="onVisibleChange"
   >
     <FormKit


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

新增和修改菜单时，标题都为编辑菜单，存在歧义

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3022

#### Special notes for your reviewer:

测试方式：新增菜单和菜单项。然后再编辑菜单和菜单项，查看title是否一样

#### Does this PR introduce a user-facing change?

```release-note
None
```