### PR TITLE
feat: add target attribute setting for menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@formkit/utils": "^1.0.0-beta.12",
     "@formkit/validation": "1.0.0-beta.12",
     "@formkit/vue": "^1.0.0-beta.12",
-    "@halo-dev/api-client": "0.0.64",
+    "@halo-dev/api-client": "0.0.66",
     "@halo-dev/components": "workspace:*",
     "@halo-dev/console-shared": "workspace:*",
     "@halo-dev/richtext-editor": "^0.0.0-alpha.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@formkit/utils': ^1.0.0-beta.12
       '@formkit/validation': 1.0.0-beta.12
       '@formkit/vue': ^1.0.0-beta.12
-      '@halo-dev/api-client': 0.0.64
+      '@halo-dev/api-client': 0.0.66
       '@halo-dev/components': workspace:*
       '@halo-dev/console-shared': workspace:*
       '@halo-dev/richtext-editor': ^0.0.0-alpha.17
@@ -108,7 +108,7 @@ importers:
       '@formkit/utils': 1.0.0-beta.12-e579559
       '@formkit/validation': 1.0.0-beta.12
       '@formkit/vue': 1.0.0-beta.12-e579559_ior6jr3fpijijuwpr34w2i25va
-      '@halo-dev/api-client': 0.0.64
+      '@halo-dev/api-client': 0.0.66
       '@halo-dev/components': link:packages/components
       '@halo-dev/console-shared': link:packages/shared
       '@halo-dev/richtext-editor': 0.0.0-alpha.17_vue@3.2.45
@@ -1992,8 +1992,8 @@ packages:
       - windicss
     dev: false
 
-  /@halo-dev/api-client/0.0.64:
-    resolution: {integrity: sha512-zzhTdRi4p7nRsWG7u85YCkoHZLHsbpuWeBCwLl5FSXxY8ruKuiOo0FypkS7Ll7505XASk4MJL6rsyeX+l7rLmQ==}
+  /@halo-dev/api-client/0.0.66:
+    resolution: {integrity: sha512-TxiNVki2FGUXYCy/zmvHQJV5BfXIF6dT3JwtoT0Vo6IjlN47lxND1y8ZV4QB+msj4u/jIF3s9skxzvMoyqRbog==}
     dev: false
 
   /@halo-dev/richtext-editor/0.0.0-alpha.17_vue@3.2.45:

--- a/src/modules/interface/menus/components/MenuItemEditingModal.vue
+++ b/src/modules/interface/menus/components/MenuItemEditingModal.vue
@@ -34,6 +34,7 @@ const initialFormState: MenuItem = {
   spec: {
     displayName: "",
     href: "",
+    target: "_self",
     children: [],
     priority: 0,
   },
@@ -326,6 +327,31 @@ const onMenuItemSourceChange = () => {
               :label="selectedRef.label"
               :type="selectedRef.inputType"
               validation="required"
+            />
+
+            <FormKit
+              v-model="formState.spec.target"
+              label="打开方式"
+              type="select"
+              name="target"
+              :options="[
+                {
+                  label: '当前窗口',
+                  value: '_self',
+                },
+                {
+                  label: '新窗口',
+                  value: '_blank',
+                },
+                {
+                  label: '父窗口',
+                  value: '_parent',
+                },
+                {
+                  label: '顶级窗口',
+                  value: '_top',
+                },
+              ]"
             />
           </div>
         </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

支持为菜单项设置链接打开方式。 适配：https://github.com/halo-dev/halo/pull/3072

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3063

#### Screenshots:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/21301288/209922511-120bc82c-4d13-4dd8-9829-0ba173cdc377.png">


#### Special notes for your reviewer:

测试方式：

1. Halo 需要切换到 https://github.com/halo-dev/halo/pull/3072 的分支。
2. Console 需要 `pnpm install`
3. 创建若干菜单项，并设置打开方式。
4. 检查是否设置正确。

#### Does this PR introduce a user-facing change?

```release-note
菜单项支持设置打开方式
```
