### PR TITLE
fix: preferred-editor annotation is not set when editing old posts

### DIFF
--- a/src/modules/contents/pages/SinglePageEditor.vue
+++ b/src/modules/contents/pages/SinglePageEditor.vue
@@ -213,6 +213,16 @@ const handleFetchContent = async () => {
         ...formState.value.page.metadata.annotations,
         "content.halo.run/preferred-editor": provider.name,
       };
+
+      const { data } =
+        await apiClient.extension.singlePage.updatecontentHaloRunV1alpha1SinglePage(
+          {
+            name: formState.value.page.metadata.name,
+            singlePage: formState.value.page,
+          }
+        );
+
+      formState.value.page = data;
     } else {
       Dialog.warning({
         title: "警告",

--- a/src/modules/contents/posts/PostEditor.vue
+++ b/src/modules/contents/posts/PostEditor.vue
@@ -221,6 +221,14 @@ const handleFetchContent = async () => {
         ...formState.value.post.metadata.annotations,
         "content.halo.run/preferred-editor": provider.name,
       };
+
+      const { data } =
+        await apiClient.extension.post.updatecontentHaloRunV1alpha1Post({
+          name: formState.value.post.metadata.name,
+          post: formState.value.post,
+        });
+
+      formState.value.post = data;
     } else {
       Dialog.warning({
         title: "警告",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

修复编辑旧文章时，没有为文章设置 `content.halo.run/preferred-editor` 的元数据的问题。

#### Which issue(s) this PR fixes:

Ref https://github.com/halo-dev/halo/issues/3080

#### Special notes for your reviewer:

测试方式：

1. 在有旧数据的情况下切换到此 PR。
2. 编辑一篇旧的文章后保存。
3. 打开文章设置，检查元数据中是否包含了 `content.halo.run/preferred-editor`

#### Does this PR introduce a user-facing change?


```release-note
None
```
