### PR TITLE
fix: add word break for long toast body

### DIFF
--- a/packages/components/src/components/toast/Toast.vue
+++ b/packages/components/src/components/toast/Toast.vue
@@ -141,7 +141,7 @@ defineExpose({ close });
   }
 
   .toast-body {
-    @apply cursor-pointer flex items-center px-2.5 py-2 overflow-hidden bg-white shadow hover:shadow-md transition-all rounded gap-2;
+    @apply cursor-pointer flex items-center px-2.5 py-2 overflow-hidden break-all bg-white shadow hover:shadow-md transition-all rounded gap-2;
   }
 
   .toast-content {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

解决提示信息过长时不能完全展示的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3163

#### Screenshots:

![image](https://user-images.githubusercontent.com/27671436/213079369-0c5db4cf-fa3d-44a3-bd53-d98ae79a6bcf.png)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
fix: add word break for long toast body
```
