### PR TITLE
feat: editor supports selecting attachments to be inserted as links

### DIFF
--- a/src/modules/contents/attachments/composables/use-attachment.ts
+++ b/src/modules/contents/attachments/composables/use-attachment.ts
@@ -295,6 +295,7 @@ export function useAttachmentSelect(
             },
           };
         }
+
         if ("url" in attachment) {
           return {
             type: "image",
@@ -304,6 +305,7 @@ export function useAttachmentSelect(
             },
           };
         }
+
         if ("spec" in attachment) {
           const { mediaType, displayName } = attachment.spec;
           const { permalink } = attachment.status || {};
@@ -334,9 +336,23 @@ export function useAttachmentSelect(
               },
             };
           }
+
+          return {
+            type: "text",
+            marks: [
+              {
+                type: "link",
+                attrs: {
+                  href: permalink,
+                },
+              },
+            ],
+            text: displayName,
+          };
         }
       })
       .filter(Boolean) as Content[];
+
     editor.value
       ?.chain()
       .focus()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

编辑器支持选择附件作为链接插入。目前在附件库选择附件时，如果非图片、视频、音频，那么就会作为链接插入。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/2673

#### Screenshots:

![2023-02-17 21 02 43](https://user-images.githubusercontent.com/21301288/219660123-b910a4d5-32e6-4606-813e-c081720556d5.gif)

#### Special notes for your reviewer:

测试方式：

1. 测试从附件库选择非图片、视频、音频的时候是否会作为链接插入即可。

#### Does this PR introduce a user-facing change?

```release-note
Console 端默认编辑器支持以链接的形式插入非图片、音视频的附件。
```
