### PR TITLE
perf: default editor's toc supports showing empty states

### DIFF
--- a/src/components/editor/DefaultEditor.vue
+++ b/src/components/editor/DefaultEditor.vue
@@ -532,7 +532,7 @@ watch(
         <VTabs v-model:active-id="extraActiveId" type="outline">
           <VTabItem id="toc" label="大纲">
             <div class="p-1 pt-0">
-              <ul class="space-y-1">
+              <ul v-if="headingNodes?.length" class="space-y-1">
                 <li
                   v-for="(node, index) in headingNodes"
                   :key="index"
@@ -559,6 +559,9 @@ watch(
                   </div>
                 </li>
               </ul>
+              <div v-else class="flex flex-col items-center py-10">
+                <span class="text-sm text-gray-600">暂无大纲</span>
+              </div>
             </div>
           </VTabItem>
           <VTabItem id="information" label="详情">


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

默认编辑器的大纲在没有内容的时候支持显示空状态的提示。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3335

#### Screenshots:

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/21301288/220002675-e16829f0-1c33-4030-a76b-4720dc7d7a69.png">

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Console 端默认编辑器的大纲列表支持显示空状态
```
