### PR TITLE
perf: disable the editor from pasting excel tables as pictures

### DIFF
--- a/src/components/editor/DefaultEditor.vue
+++ b/src/components/editor/DefaultEditor.vue
@@ -301,6 +301,12 @@ const editor = useEditor({
       return false;
     },
     handlePaste: (view, event: ClipboardEvent) => {
+      const types = Array.from(event.clipboardData?.types || []);
+
+      if (["text/plain", "text/html"].includes(types[0])) {
+        return;
+      }
+
       const images = Array.from(event.clipboardData?.items || [])
         .map((item) => {
           return item.getAsFile();


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

禁止在编辑器粘贴 Excel 表格时，将表格转为图片的形式上传。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3348

#### Screenshots:

before:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/21301288/220243681-eb07502a-0fc5-4e69-9cd3-61c3b89cb542.png">

after:

<img width="815" alt="image" src="https://user-images.githubusercontent.com/21301288/220243630-ca7c2700-ff61-4893-a857-94860e4a899b.png">


#### Special notes for your reviewer:

测试方式：

1. 使用 Excel 或者 macOS 下的 Numbers 创建一个表格。
2. 复制整个表格或者某几个单元格，并粘贴到 Halo 的编辑器。
3. 观察是否有将内容转为图片并上传。

#### Does this PR introduce a user-facing change?

```release-note
Console 端禁止在编辑器粘贴 Excel 表格以图片的形式上传。
```
