### PR TITLE
perf: hide active button when theme is activated

### DIFF
--- a/src/modules/interface/themes/components/components/ThemeListItem.vue
+++ b/src/modules/interface/themes/components/components/ThemeListItem.vue
@@ -178,7 +178,13 @@ const handleUninstall = async (theme: Theme, deleteExtensions?: boolean) => {
       v-if="currentUserHasPermission(['system:themes:manage'])"
       #dropdownItems
     >
-      <VButton v-close-popper block type="secondary" @click="handleActiveTheme">
+      <VButton
+        v-if="!isActivated"
+        v-close-popper
+        block
+        type="secondary"
+        @click="handleActiveTheme"
+      >
         启用
       </VButton>
       <VButton v-close-popper block type="default" @click="emit('upgrade')">

--- a/src/modules/interface/themes/components/preview/ThemePreviewListItem.vue
+++ b/src/modules/interface/themes/components/preview/ThemePreviewListItem.vue
@@ -69,7 +69,13 @@ const { isActivated, handleActiveTheme } = useThemeLifeCycle(theme);
     </template>
 
     <template #dropdownItems>
-      <VButton v-close-popper block type="secondary" @click="handleActiveTheme">
+      <VButton
+        v-if="!isActivated"
+        v-close-popper
+        block
+        type="secondary"
+        @click="handleActiveTheme"
+      >
         启用
       </VButton>
       <VButton


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

当主题已经启用时，隐藏启用的按钮。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3059

#### Screenshots:

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/21301288/220517066-67ee2f25-1b64-47c0-8b4c-3bdd6b3cb9f1.png">

#### Special notes for your reviewer:

测试方式：

1. 在主题管理列表检查已启用主题是否还有启用按钮即可。

#### Does this PR introduce a user-facing change?

```release-note
Console 端主题管理列表隐藏已启用主题的启用按钮。
```
