### PR TITLE
fix: user filter list will fail to load the avatar after searching

### DIFF
--- a/src/components/dropdown-selector/UserDropdownSelector.vue
+++ b/src/components/dropdown-selector/UserDropdownSelector.vue
@@ -96,6 +96,7 @@ const searchResults = computed(() => {
                   <VEntityField>
                     <template #description>
                       <VAvatar
+                        :key="user.metadata.name"
                         :alt="user.spec.displayName"
                         :src="user.spec.avatar"
                         size="md"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

修复用户筛选列表在搜索之后无法正常加载头像的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3361

#### Screenshots:

<img width="455" alt="image" src="https://user-images.githubusercontent.com/21301288/221108789-291999ab-ee4f-478c-900b-4273e3780357.png">

#### Special notes for your reviewer:
 
测试方式：

1. 创建若干用户并设置头像。
2. 打开文章管理的用户筛选项，尝试输入关键词搜索，观察搜索出的用户头像是否加载正常。

#### Does this PR introduce a user-facing change?


```release-note
修复 Console 端用户筛选项，输入关键词搜索之后无法加载头像的问题。
```
