### PR TITLE
fix: incorrect default pagination number of attachment list

### DIFF
--- a/src/modules/contents/attachments/AttachmentList.vue
+++ b/src/modules/contents/attachments/AttachmentList.vue
@@ -135,7 +135,7 @@ function handleClearFilters() {
 
 const keyword = ref<string>("");
 const page = ref<number>(1);
-const size = ref<number>(20);
+const size = ref<number>(60);
 
 const {
   attachments,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

修复附件管理默认分页条数不正确的问题，应该是在 https://github.com/halo-dev/console/pull/878 中测试分页之后没有改回原来的值导致的。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3406

#### Special notes for your reviewer:

测试附件管理页面默认分页条数是否为 60 即可。

<img width="1423" alt="image" src="https://user-images.githubusercontent.com/21301288/221489138-be0ecfb1-2bc0-4732-8554-afdfc5bf2dfe.png">

#### Does this PR introduce a user-facing change?

```release-note
None
```
