### PR TITLE
fix: get the wrong link after selecting an attachment

### DIFF
--- a/src/modules/contents/attachments/composables/use-attachment.ts
+++ b/src/modules/contents/attachments/composables/use-attachment.ts
@@ -314,11 +314,7 @@ export function useAttachmentSelect(
       })
       .filter(Boolean) as Content[];
 
-    editor.value
-      ?.chain()
-      .focus()
-      .insertContent([...contents, { type: "paragraph", content: "" }])
-      .run();
+    editor.value?.chain().focus().insertContent(contents).run();
   };
 
   return {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

修复默认编辑器从附件库选择非图片、音视频的附件，以链接的形式插入之后得到的链接不正确的问题。

#### Which issue(s) this PR fixes:

Fixes https://github.com/halo-dev/halo/issues/3408

#### Screenshots:

before:

<img width="995" alt="image" src="https://user-images.githubusercontent.com/21301288/221510856-76eaa125-c13e-472a-8073-7f9f58bb4bd2.png">

after:

<img width="924" alt="image" src="https://user-images.githubusercontent.com/21301288/221510749-c27fc083-3978-4139-959a-426499016d12.png">


#### Special notes for your reviewer:

测试方式：

1. 上传若干 zip 格式附件。
2. 在编辑器中选择这些附件并插入，检查链接是否正确。

#### Does this PR introduce a user-facing change?

```release-note
None
```
