### PR TITLE
perf: mute the start plugin request in setup page

### DIFF
--- a/src/views/system/Setup.vue
+++ b/src/views/system/Setup.vue
@@ -44,10 +44,15 @@ const { mutate: pluginStartMutate } = useMutation({
 
     pluginToUpdate.spec.enabled = true;
 
-    return apiClient.extension.plugin.updatepluginHaloRunV1alpha1Plugin({
-      name: plugin.metadata.name,
-      plugin: pluginToUpdate,
-    });
+    return apiClient.extension.plugin.updatepluginHaloRunV1alpha1Plugin(
+      {
+        name: plugin.metadata.name,
+        plugin: pluginToUpdate,
+      },
+      {
+        mute: true,
+      }
+    );
   },
   retry: 3,
 });


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

隐藏在初始化页面启用插件时的错误提示，因为会重试三次，所以不需要提示。

```release-note
None
```
