### PR TITLE
fix: the rawType of Content was not updated when switching editors

### DIFF
--- a/src/modules/contents/pages/SinglePageEditor.vue
+++ b/src/modules/contents/pages/SinglePageEditor.vue
@@ -48,6 +48,7 @@ const handleChangeEditorProvider = (provider: EditorProvider) => {
   formState.value.page.metadata.annotations = {
     "content.halo.run/preferred-editor": provider.name,
   };
+  formState.value.content.rawType = provider.rawType;
 };
 
 // SinglePage form

--- a/src/modules/contents/posts/PostEditor.vue
+++ b/src/modules/contents/posts/PostEditor.vue
@@ -48,6 +48,7 @@ const handleChangeEditorProvider = (provider: EditorProvider) => {
   formState.value.post.metadata.annotations = {
     "content.halo.run/preferred-editor": provider.name,
   };
+  formState.value.content.rawType = provider.rawType;
 };
 
 // Post form


### PR DESCRIPTION
> **Warning**
>
> 此 PR 的改动来自：<https://github.com/halo-dev/halo/pull/3516>
> 因为目前 Console 仓库已经合并到 Halo 主仓库，但主仓库的 release-2.3 分支不包含 Console，所以如果需要发布 2.3.x 的 patch 版本，依旧需要在此仓库修改。

#### What type of PR is this?

/kind bug
/milestone 2.3.2

#### What this PR does / why we need it:

修复在新建文章时，首次切换编辑器后没有设置内容 rawType 资源为对应编辑器类型的问题。

#### Which issue(s) this PR fixes:

Fixes #3512 

#### Special notes for your reviewer:

测试方式：

1. 安装任意一个编辑器插件，比如：https://github.com/halo-sigs/plugin-stackedit
1. 新建文章，选择安装的编辑器。
1. 发布文章。
1. 卸载或者停止编辑器。
1. 重新编辑刚刚创建的文章，如果提示 `未找到符合 markdown 格式的编辑器，请检查是否已安装编辑器插件` 则代表正常。

#### Does this PR introduce a user-facing change?

```release-note
修复在新建文章时，首次切换编辑器后没有设置内容 rawType 资源为对应编辑器类型的问题。
```
